### PR TITLE
Canonicalize central CI caller shape

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,36 +1,13 @@
 name: Maven CI
-
 on:
   push:
-    branches:
-      - '**'
+    branches: ['**']
   pull_request:
-
 permissions:
   contents: read
-
 jobs:
-  verify:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version: ['17', '21']
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java-version }}
-          cache: maven
-
-      - name: Run tests
-        run: mvn -B test
-
-      - name: Build package
-        run: mvn -B package
+  ci:
+    # Pin to the floating major tag @v1 to auto-receive security re-pins; immutable tags (e.g. v1.1.0) remain available for strict pinning.
+    uses: UltiKits/ci-workflows/.github/workflows/maven-ci.yml@v1
+    with:
+      needs-nms: false


### PR DESCRIPTION
Phase 17-04 Gate B1/B2 evidence PR.

- Uses central `ci-workflows@v1` reusable Maven CI caller.
- Sets non-NMS caller input `needs-nms: false`.
- Workflow-only diff: `.github/workflows/maven-ci.yml`.
- No Tooling manifest update and no merge in this gate.