### PR TITLE
fix: declare api-version 621 to match the symbols this module needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UltiEssentials
 
-[![UltiTools-API](https://img.shields.io/badge/UltiTools--API-6.2.0-blue)](https://github.com/UltiKits/UltiTools-Reborn)
+[![UltiTools-API](https://img.shields.io/badge/UltiTools--API-6.2.1-blue)](https://github.com/UltiKits/UltiTools-Reborn)
 [![Minecraft](https://img.shields.io/badge/Minecraft-1.8--1.21-green)](https://www.spigotmc.org/)
 [![Java](https://img.shields.io/badge/Java-8+-orange)](https://www.java.com/)
 
@@ -64,7 +64,7 @@ UltiEssentials 是基于 UltiTools-API 框架开发的服务器基础功能插�
 
 ## 📦 安装
 
-1. 确保服务器已安装 [UltiTools-API](https://github.com/UltiKits/UltiTools-Reborn) 6.2.0+
+1. 确保服务器已安装 [UltiTools-API](https://github.com/UltiKits/UltiTools-Reborn) 6.2.1+
 2. 将 `UltiEssentials-1.0.0.jar` 放入 `plugins/UltiTools/plugins/` 目录
 3. 重启服务器或使用 `/ul reload` 重载插件
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,5 +4,5 @@ main: com.ultikits.plugins.essentials.UltiEssentials
 authors:
   - wisdommen
   - UltiKits Team
-api-version: 620
+api-version: 621
 loadAfter: []


### PR DESCRIPTION
本模块的字节码引用了 `DataOperator.insert` / `update(T)`（UltiMail 还有 `getById`）在 UltiTools-API **6.2.1** 才有的 `BaseDataEntity` 描述符，但 `plugin.yml` 声明的地板还是 `620`。

`PluginManager.isUltiToolsVersionCompatible` 只读 `api-version` —— `pom.xml` 里的 pin 是 `provided` scope，不进 JAR，框架运行时看不到它。所以装了框架 **6.2.0** 的服务器会**放行这个 JAR，然后在第一次数据读写时 `NoSuchMethodError`**。而且 Java 是惰性解析的，不碰数据路径的服主今天还看不出问题。

`621` 是**算出来的，不是估的**：把构建产物逐符号比对 6.2.0 与 6.2.1，前者报缺失、后者为 0。

根因与全量实测见 UltiKits/UltiTools-Reborn#284（框架 6.2.1 这个 PATCH 改了 `DataOperator` 三个方法的描述符）。15 个模块里 11 个中招，4 个不碰 ORM 的干净。

**不为此单独发版。** 修正后的地板随本模块下一次真正发布带出，那一版按模块版本号规范（`api-version` 抬高即 MAJOR）是 MAJOR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzTkgBjRdaTcLrbvkoaFkp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin’s supported Bukkit API version to 621.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->