### PR TITLE
feat: pin UltiTools-API to 6.3.0-SNAPSHOT and add live coverage gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -6,8 +6,23 @@ on:
 permissions:
   contents: read
 jobs:
-  ci:
-    # Pin to the floating major tag @v1 to auto-receive security re-pins; immutable tags (e.g. v1.1.0) remain available for strict pinning.
-    uses: UltiKits/ci-workflows/.github/workflows/maven-ci.yml@v1
-    with:
-      needs-nms: false
+  verify:
+    name: Test, coverage gate & package (JDK ${{ matrix.java-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['17', '21']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+      - name: Verify
+        # verify runs test, then jacoco:check, then package -- one command replaces the shared
+        # workflow's separate test and package steps, and is the only phase at which the gate runs.
+        run: mvn -B verify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,11 +30,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Install parent POM
-        run: |
-          git clone --depth 1 https://github.com/UltiKits/ultikits-module-parent.git /tmp/parent-pom
-          cd /tmp/parent-pom && mvn install -N -q
-
       - name: Extract version
         id: version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ target/
 .DS_Store
 Thumbs.db
 CLAUDE.md
+
+# Tooling artifacts
+.factorypath
+PROJECT.md

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ultitools.version>6.2.1</ultitools.version>
+        <ultitools.version>6.3.0-SNAPSHOT</ultitools.version>
     </properties>
 
     <repositories>
@@ -41,6 +41,12 @@
         <repository>
             <id>placeholderapi</id>
             <url>https://repo.helpch.at/releases/</url>
+        </repository>
+        <repository>
+            <id>central-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
 
@@ -183,6 +189,39 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <!-- D-07: the GUI layer is verified by Phase 10's real-machine UAT
+                                     instead of by this gate. This module has no gui package, so
+                                     this exclude is written for comparability with the other
+                                     fifteen module poms; confirm it is inert with the check-vs-report
+                                     class count rather than assuming so. -->
+                                <exclude>**/gui/**</exclude>
+                            </excludes>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/test/java/com/ultikits/plugins/essentials/commands/BanCommandBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/BanCommandBehaviorTest.java
@@ -1,0 +1,122 @@
+package com.ultikits.plugins.essentials.commands;
+
+import com.ultikits.plugins.essentials.service.BanService;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the two decisions {@code BanCommandsTest} does not reach for {@link BanCommand}: the
+ * player-existence rejection (every existing test stubs a target that exists), and the
+ * {@code suggest} arg-count routing.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("BanCommand behaviour Tests")
+class BanCommandBehaviorTest {
+
+    private BanCommand command;
+    private BanService banService;
+    private Player player;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+        banService = mock(BanService.class);
+        command = new BanCommand();
+        EssentialsTestHelper.setField(command, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(command, "banService", banService);
+        player = EssentialsTestHelper.createMockPlayer("TestPlayer", UUID.randomUUID());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    @Test
+    @DisplayName("A name with no UUID and no play history is rejected without calling the ban service")
+    void nonexistentPlayerIsRejected() {
+        OfflinePlayer target = mock(OfflinePlayer.class);
+        when(target.getUniqueId()).thenReturn(null);
+        when(target.hasPlayedBefore()).thenReturn(false);
+        Server server = Bukkit.getServer();
+        when(server.getOfflinePlayer(eq("Nobody"))).thenReturn(target);
+
+        command.banWithReason(player, "Nobody", "reason");
+
+        verify(player).sendMessage(contains("Nobody"));
+        verifyNoInteractions(banService);
+    }
+
+    @Test
+    @DisplayName("A UUID-less name that HAS played before is not rejected by the existence check")
+    void uuidLessButPreviouslyPlayedNameProceeds() {
+        UUID targetUuid = UUID.randomUUID();
+        OfflinePlayer target = mock(OfflinePlayer.class);
+        // getUniqueId() is null on first read (the existence check) -- a real quirk this test
+        // pins as its own decision, distinct from "never played" -- then non-null when banPlayer
+        // itself is invoked, matching what banWithReason actually passes downstream.
+        when(target.getUniqueId()).thenReturn(null, targetUuid);
+        when(target.hasPlayedBefore()).thenReturn(true);
+        when(target.getName()).thenReturn("ReturningPlayer");
+        Server server = Bukkit.getServer();
+        when(server.getOfflinePlayer(eq("ReturningPlayer"))).thenReturn(target);
+        when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString()))
+                .thenReturn(BanService.BanResult.SUCCESS);
+
+        command.banWithReason(player, "ReturningPlayer", "reason");
+
+        verify(banService).banPlayer(eq(targetUuid), eq("ReturningPlayer"), eq("reason"),
+                any(), anyString());
+    }
+
+    @Test
+    @DisplayName("A target with no display name falls back to the typed player name in the ban call")
+    void nullTargetNameFallsBackToTypedName() {
+        UUID targetUuid = UUID.randomUUID();
+        OfflinePlayer target = mock(OfflinePlayer.class);
+        when(target.getUniqueId()).thenReturn(targetUuid);
+        when(target.hasPlayedBefore()).thenReturn(true);
+        when(target.getName()).thenReturn(null);
+        Server server = Bukkit.getServer();
+        when(server.getOfflinePlayer(eq("TypedName"))).thenReturn(target);
+        when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString()))
+                .thenReturn(BanService.BanResult.SUCCESS);
+
+        command.banWithReason(player, "TypedName", "reason");
+
+        verify(banService).banPlayer(eq(targetUuid), eq("TypedName"), eq("reason"), any(), anyString());
+    }
+
+    @Test
+    @DisplayName("suggest with one argument suggests online player names")
+    void suggestWithOneArgSuggestsOnlinePlayers() {
+        Player online = EssentialsTestHelper.createMockPlayer("Alice", UUID.randomUUID());
+        doReturn(java.util.Collections.singletonList(online))
+                .when(EssentialsTestHelper.getMockServer()).getOnlinePlayers();
+
+        List<String> result = command.suggest(player, mock(org.bukkit.command.Command.class), new String[]{"A"});
+
+        assertThat(result).contains("Alice");
+    }
+
+    @Test
+    @DisplayName("suggest with a non-1 argument count defers to the framework's own mapping-based completion")
+    void suggestWithOtherArgCountDefersToSuper() {
+        List<String> result = command.suggest(player, mock(org.bukkit.command.Command.class), new String[]{});
+
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/commands/BanCommandBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/BanCommandBehaviorTest.java
@@ -115,8 +115,18 @@ class BanCommandBehaviorTest {
     @Test
     @DisplayName("suggest with a non-1 argument count defers to the framework's own mapping-based completion")
     void suggestWithOtherArgCountDefersToSuper() {
+        // Stub an online player so a regression that mis-routes empty args into
+        // suggestOnlinePlayers(...) would return a non-empty ["Alice"] list. The correct
+        // super.suggest(...) path (CommandTabCompletionDispatch.suggest) returns a fresh empty
+        // list unconditionally for a zero-length argument vector, regardless of who is online --
+        // so isEmpty() distinguishes "delegated to super" from "delegated to the wrong branch and
+        // happened to return something non-null", which a bare isNotNull() cannot.
+        Player online = EssentialsTestHelper.createMockPlayer("Alice", UUID.randomUUID());
+        doReturn(java.util.Collections.singletonList(online))
+                .when(EssentialsTestHelper.getMockServer()).getOnlinePlayers();
+
         List<String> result = command.suggest(player, mock(org.bukkit.command.Command.class), new String[]{});
 
-        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/ultikits/plugins/essentials/commands/BaseEssentialsCommandBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/BaseEssentialsCommandBehaviorTest.java
@@ -1,0 +1,156 @@
+package com.ultikits.plugins.essentials.commands;
+
+import com.ultikits.plugins.essentials.enums.TeleportResult;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import com.ultikits.ultitools.annotations.command.CmdExecutor;
+import com.ultikits.ultitools.annotations.command.CmdTarget;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link BaseEssentialsCommand}'s {@code checkFeatureEnabled} and
+ * {@code sendTeleportResultMessage} -- the class's own real behaviour, entirely untested
+ * because the only existing test class for it ({@code BaseEssentialsCommandTest}) is
+ * {@code @Disabled} (the abandoned MockBukkit harness). This class exercises the same
+ * decisions with plain Mockito instead, per the {@code ChannelCommandsTest} idiom.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("BaseEssentialsCommand behaviour Tests (Mockito)")
+class BaseEssentialsCommandBehaviorTest {
+
+    private TestCommand command;
+    private Player player;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+        command = new TestCommand();
+        EssentialsTestHelper.setField(command, "plugin", EssentialsTestHelper.getMockPlugin());
+        player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    @Nested
+    @DisplayName("checkFeatureEnabled")
+    class CheckFeatureEnabledTests {
+
+        @Test
+        @DisplayName("Returns true and sends nothing when the feature is enabled")
+        void returnsTrueWhenEnabled() {
+            boolean result = command.testCheckFeatureEnabled(true, player);
+
+            assertThat(result).isTrue();
+            verify(player, never()).sendMessage(anyString());
+        }
+
+        @Test
+        @DisplayName("Returns false and sends the disabled message when the feature is disabled")
+        void returnsFalseWhenDisabled() {
+            boolean result = command.testCheckFeatureEnabled(false, player);
+
+            assertThat(result).isFalse();
+            verify(player).sendMessage("feature_disabled");
+        }
+    }
+
+    @Nested
+    @DisplayName("sendTeleportResultMessage")
+    class SendTeleportResultMessageTests {
+
+        @Test
+        @DisplayName("SUCCESS sends the success message")
+        void success() {
+            command.testSendTeleportResultMessage(player, TeleportResult.SUCCESS);
+            verify(player).sendMessage("teleport_success");
+        }
+
+        @Test
+        @DisplayName("WARMUP_STARTED sends the warmup message")
+        void warmupStarted() {
+            command.testSendTeleportResultMessage(player, TeleportResult.WARMUP_STARTED);
+            verify(player).sendMessage("teleport_warmup_started");
+        }
+
+        @Test
+        @DisplayName("NOT_FOUND sends the target-not-found message")
+        void notFound() {
+            command.testSendTeleportResultMessage(player, TeleportResult.NOT_FOUND);
+            verify(player).sendMessage("teleport_target_not_found");
+        }
+
+        @Test
+        @DisplayName("WORLD_NOT_FOUND sends the world-not-found message")
+        void worldNotFound() {
+            command.testSendTeleportResultMessage(player, TeleportResult.WORLD_NOT_FOUND);
+            verify(player).sendMessage("teleport_world_not_found");
+        }
+
+        @Test
+        @DisplayName("NO_PERMISSION sends the no-permission message")
+        void noPermission() {
+            command.testSendTeleportResultMessage(player, TeleportResult.NO_PERMISSION);
+            verify(player).sendMessage("teleport_no_permission");
+        }
+
+        @Test
+        @DisplayName("ALREADY_TELEPORTING sends the already-in-progress message")
+        void alreadyTeleporting() {
+            command.testSendTeleportResultMessage(player, TeleportResult.ALREADY_TELEPORTING);
+            verify(player).sendMessage("teleport_already_in_progress");
+        }
+
+        @Test
+        @DisplayName("DISABLED sends the feature-disabled message")
+        void disabled() {
+            command.testSendTeleportResultMessage(player, TeleportResult.DISABLED);
+            verify(player).sendMessage("feature_disabled");
+        }
+
+        @Test
+        @DisplayName("CANCELLED sends the cancelled message")
+        void cancelled() {
+            command.testSendTeleportResultMessage(player, TeleportResult.CANCELLED);
+            verify(player).sendMessage("teleport_cancelled");
+        }
+    }
+
+    /**
+     * Test subclass that exposes the protected helper methods, and overrides {@code i18n} to
+     * return the key verbatim so assertions can check the routed key rather than a translated
+     * string that depends on the loaded language file.
+     */
+    @CmdTarget(CmdTarget.CmdTargetType.PLAYER)
+    @CmdExecutor(alias = {"testbase"}, permission = "test.testbase", description = "Test command")
+    static class TestCommand extends BaseEssentialsCommand {
+
+        @Override
+        protected String i18n(String key) {
+            return key;
+        }
+
+        @Override
+        protected void handleHelp(CommandSender sender) {
+            sender.sendMessage("help");
+        }
+
+        boolean testCheckFeatureEnabled(boolean enabled, CommandSender sender) {
+            return checkFeatureEnabled(enabled, sender);
+        }
+
+        void testSendTeleportResultMessage(Player player, TeleportResult result) {
+            sendTeleportResultMessage(player, result);
+        }
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/commands/TempBanCommandTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/TempBanCommandTest.java
@@ -1,0 +1,222 @@
+package com.ultikits.plugins.essentials.commands;
+
+import com.ultikits.plugins.essentials.service.BanService;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link TempBanCommand}, which has no prior test class at all: player-existence
+ * validation, duration-format validation, the {@code BanResult} switch driving the broadcast,
+ * and the tab-completion arg-count routing.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("TempBanCommand Tests")
+class TempBanCommandTest {
+
+    private TempBanCommand command;
+    private BanService banService;
+    private Player player;
+    private UUID playerUuid;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+        command = new TempBanCommand();
+        banService = mock(BanService.class);
+        EssentialsTestHelper.setField(command, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(command, "banService", banService);
+
+        playerUuid = UUID.randomUUID();
+        player = EssentialsTestHelper.createMockPlayer("TestPlayer", playerUuid);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private OfflinePlayer stubExistingTarget(String name, UUID uuid) {
+        OfflinePlayer target = mock(OfflinePlayer.class);
+        when(target.getUniqueId()).thenReturn(uuid);
+        when(target.hasPlayedBefore()).thenReturn(true);
+        when(target.getName()).thenReturn(name);
+        Server server = Bukkit.getServer();
+        when(server.getOfflinePlayer(eq(name))).thenReturn(target);
+        return target;
+    }
+
+    @Nested
+    @DisplayName("Player-existence validation")
+    class PlayerExistenceTests {
+
+        @Test
+        @DisplayName("A name with no UUID and no play history is rejected without calling the ban service")
+        void nonexistentPlayerIsRejected() {
+            OfflinePlayer target = mock(OfflinePlayer.class);
+            when(target.getUniqueId()).thenReturn(null);
+            when(target.hasPlayedBefore()).thenReturn(false);
+            Server server = Bukkit.getServer();
+            when(server.getOfflinePlayer(eq("Nobody"))).thenReturn(target);
+
+            command.tempbanWithReason(player, "Nobody", "1d", "reason");
+
+            verify(player).sendMessage(contains("Nobody"));
+            verifyNoInteractions(banService);
+        }
+    }
+
+    @Nested
+    @DisplayName("Duration-format validation")
+    class DurationFormatTests {
+
+        @Test
+        @DisplayName("An invalid duration format is rejected with two usage messages, and the ban service is never called")
+        void invalidDurationIsRejected() {
+            stubExistingTarget("BadPlayer", UUID.randomUUID());
+
+            command.tempbanWithReason(player, "BadPlayer", "not-a-duration", "reason");
+
+            verify(player, times(2)).sendMessage(anyString());
+            verifyNoInteractions(banService);
+        }
+
+        @Test
+        @DisplayName("A valid duration format proceeds to call the ban service")
+        void validDurationProceeds() {
+            UUID targetUuid = UUID.randomUUID();
+            stubExistingTarget("BadPlayer", targetUuid);
+            when(banService.banPlayer(eq(targetUuid), eq("BadPlayer"), anyString(), any(), anyString(),
+                    anyLong(), isNull())).thenReturn(BanService.BanResult.SUCCESS);
+
+            command.tempbanWithReason(player, "BadPlayer", "1d", "reason");
+
+            verify(banService).banPlayer(eq(targetUuid), eq("BadPlayer"), eq("reason"),
+                    eq(playerUuid), eq("TestPlayer"), anyLong(), isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("BanResult routing")
+    class BanResultRoutingTests {
+
+        @Test
+        @DisplayName("SUCCESS broadcasts the ban announcement and the reason")
+        void successBroadcasts() {
+            UUID targetUuid = UUID.randomUUID();
+            stubExistingTarget("BadPlayer", targetUuid);
+            when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString(), anyLong(), isNull()))
+                    .thenReturn(BanService.BanResult.SUCCESS);
+
+            try (org.mockito.MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+                command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
+
+                bukkit.verify(() -> Bukkit.broadcastMessage(contains("BadPlayer")));
+                bukkit.verify(() -> Bukkit.broadcastMessage(contains("hacking")));
+            }
+        }
+
+        @Test
+        @DisplayName("ALREADY_BANNED sends the sender a rejection message, no broadcast")
+        void alreadyBannedNotifiesSenderOnly() {
+            UUID targetUuid = UUID.randomUUID();
+            stubExistingTarget("BadPlayer", targetUuid);
+            when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString(), anyLong(), isNull()))
+                    .thenReturn(BanService.BanResult.ALREADY_BANNED);
+
+            command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
+
+            verify(player).sendMessage(anyString());
+        }
+
+        @Test
+        @DisplayName("DISABLED sends the sender a feature-disabled message, no broadcast")
+        void disabledNotifiesSenderOnly() {
+            UUID targetUuid = UUID.randomUUID();
+            stubExistingTarget("BadPlayer", targetUuid);
+            when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString(), anyLong(), isNull()))
+                    .thenReturn(BanService.BanResult.DISABLED);
+
+            command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
+
+            verify(player).sendMessage(anyString());
+        }
+
+        @Test
+        @DisplayName("A console sender is recorded as operator name \"Console\" with a null operator UUID")
+        void consoleSenderRecordsConsoleOperator() {
+            UUID targetUuid = UUID.randomUUID();
+            stubExistingTarget("BadPlayer", targetUuid);
+            CommandSender console = mock(CommandSender.class);
+            when(console.getName()).thenReturn("CONSOLE");
+            when(banService.banPlayer(eq(targetUuid), anyString(), anyString(), isNull(), eq("Console"),
+                    anyLong(), isNull())).thenReturn(BanService.BanResult.SUCCESS);
+
+            try (org.mockito.MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+                command.tempbanWithReason(console, "BadPlayer", "1d", "hacking");
+            }
+
+            verify(banService).banPlayer(eq(targetUuid), anyString(), anyString(), isNull(), eq("Console"),
+                    anyLong(), isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("tempban (default reason)")
+    class DefaultReasonTests {
+
+        @Test
+        @DisplayName("The 2-arg form delegates with the default reason")
+        void delegatesWithDefaultReason() {
+            UUID targetUuid = UUID.randomUUID();
+            stubExistingTarget("BadPlayer", targetUuid);
+            when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString(), anyLong(), isNull()))
+                    .thenReturn(BanService.BanResult.SUCCESS);
+
+            try (org.mockito.MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+                command.tempban(player, "BadPlayer", "1d");
+            }
+
+            verify(banService).banPlayer(eq(targetUuid), anyString(), eq("无理由"),
+                    eq(playerUuid), eq("TestPlayer"), anyLong(), isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("suggest")
+    class SuggestTests {
+
+        @Test
+        @DisplayName("One argument suggests online player names")
+        void oneArgSuggestsOnlinePlayers() {
+            Player online = EssentialsTestHelper.createMockPlayer("Alice", UUID.randomUUID());
+            doReturn(java.util.Collections.singletonList(online))
+                    .when(EssentialsTestHelper.getMockServer()).getOnlinePlayers();
+
+            List<String> result = command.suggest(player, mock(org.bukkit.command.Command.class), new String[]{"A"});
+
+            assertThat(result).contains("Alice");
+        }
+
+        @Test
+        @DisplayName("Two arguments suggest the fixed set of duration presets")
+        void twoArgsSuggestDurationPresets() {
+            List<String> result = command.suggest(player, mock(org.bukkit.command.Command.class), new String[]{"BadPlayer", ""});
+
+            assertThat(result).contains("1h", "1d", "1w");
+        }
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/commands/TempBanCommandTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/TempBanCommandTest.java
@@ -90,7 +90,10 @@ class TempBanCommandTest {
 
             command.tempbanWithReason(player, "BadPlayer", "not-a-duration", "reason");
 
-            verify(player, times(2)).sendMessage(anyString());
+            // Exact content, not just count -- a regression that sent two different (but still
+            // wrong) messages would still satisfy times(2).sendMessage(anyString()).
+            verify(player).sendMessage(eq("§c无效的时长格式"));
+            verify(player).sendMessage(eq("§7示例: 1d, 2h, 30m, 1w, 1d12h30m"));
             verifyNoInteractions(banService);
         }
 
@@ -137,9 +140,16 @@ class TempBanCommandTest {
             when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString(), anyLong(), isNull()))
                     .thenReturn(BanService.BanResult.ALREADY_BANNED);
 
-            command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
+            // Wrap Bukkit statics so an unwanted Bukkit.broadcastMessage(...) added to this
+            // branch is actually observed, instead of hitting the real static -> mocked-server
+            // path unnoticed. Exact message content, not just anyString(), so the
+            // ALREADY_BANNED and DISABLED branches can't pass with their messages swapped.
+            try (org.mockito.MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+                command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
 
-            verify(player).sendMessage(anyString());
+                verify(player).sendMessage(eq("§c该玩家已被封禁"));
+                bukkit.verify(() -> Bukkit.broadcastMessage(anyString()), never());
+            }
         }
 
         @Test
@@ -150,9 +160,12 @@ class TempBanCommandTest {
             when(banService.banPlayer(any(), anyString(), anyString(), any(), anyString(), anyLong(), isNull()))
                     .thenReturn(BanService.BanResult.DISABLED);
 
-            command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
+            try (org.mockito.MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+                command.tempbanWithReason(player, "BadPlayer", "1d", "hacking");
 
-            verify(player).sendMessage(anyString());
+                verify(player).sendMessage(eq("§c封禁功能已禁用"));
+                bukkit.verify(() -> Bukkit.broadcastMessage(anyString()), never());
+            }
         }
 
         @Test

--- a/src/test/java/com/ultikits/plugins/essentials/commands/TpaHereCommandResultRoutingTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/TpaHereCommandResultRoutingTest.java
@@ -1,0 +1,112 @@
+package com.ultikits.plugins.essentials.commands;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.service.TpaService;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the {@code TpaResult} directions {@code TpaCommandsTest}'s {@code TpaHereCommandTests}
+ * nested class leaves untested (only SENT and SELF_REQUEST are exercised there, and its
+ * offline-player test only covers {@code target == null}, never a target that is found but
+ * {@code isOnline()} returns false).
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("TpaHereCommand result-routing Tests")
+class TpaHereCommandResultRoutingTest {
+
+    private TpaHereCommand command;
+    private EssentialsConfig config;
+    private TpaService tpaService;
+    private Player sender;
+    private Player target;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+        config = new EssentialsConfig();
+        tpaService = mock(TpaService.class);
+        sender = EssentialsTestHelper.createMockPlayer("Sender", UUID.randomUUID());
+        target = EssentialsTestHelper.createMockPlayer("Target", UUID.randomUUID());
+
+        command = new TpaHereCommand();
+        EssentialsTestHelper.setField(command, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(command, "tpaService", tpaService);
+        EssentialsTestHelper.setField(command, "config", config);
+
+        Server server = Bukkit.getServer();
+        when(server.getPlayer(eq("Target"))).thenReturn(target);
+        when(target.isOnline()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    @Test
+    @DisplayName("A target found by name but not online is rejected the same as a nonexistent target")
+    void foundButOfflineTargetIsRejected() {
+        when(target.isOnline()).thenReturn(false);
+
+        command.sendTpaHere(sender, "Target");
+
+        verify(tpaService, never()).sendTpaHereRequest(any(), any());
+        verify(sender).sendMessage(anyString());
+    }
+
+    @Test
+    @DisplayName("TARGET_BUSY notifies the sender that the target has a pending request")
+    void targetBusyNotifiesSender() {
+        when(tpaService.sendTpaHereRequest(sender, target)).thenReturn(TpaService.TpaResult.TARGET_BUSY);
+
+        command.sendTpaHere(sender, "Target");
+
+        verify(sender).sendMessage(anyString());
+        verify(target, never()).sendMessage(anyString());
+    }
+
+    @Test
+    @DisplayName("ON_COOLDOWN reports the remaining cooldown seconds to the sender")
+    void onCooldownReportsRemainingSeconds() {
+        when(tpaService.sendTpaHereRequest(sender, target)).thenReturn(TpaService.TpaResult.ON_COOLDOWN);
+        when(tpaService.getRemainingCooldown(sender.getUniqueId())).thenReturn(17);
+
+        command.sendTpaHere(sender, "Target");
+
+        verify(sender).sendMessage(contains("17"));
+    }
+
+    @Test
+    @DisplayName("CROSS_WORLD_DISABLED notifies the sender that cross-world teleport is not allowed")
+    void crossWorldDisabledNotifiesSender() {
+        when(tpaService.sendTpaHereRequest(sender, target)).thenReturn(TpaService.TpaResult.CROSS_WORLD_DISABLED);
+
+        command.sendTpaHere(sender, "Target");
+
+        verify(sender).sendMessage(anyString());
+        verify(target, never()).sendMessage(anyString());
+    }
+
+    @Test
+    @DisplayName("DISABLED (from the service layer) notifies the sender the feature is off")
+    void serviceDisabledNotifiesSender() {
+        when(tpaService.sendTpaHereRequest(sender, target)).thenReturn(TpaService.TpaResult.DISABLED);
+
+        command.sendTpaHere(sender, "Target");
+
+        verify(sender).sendMessage(anyString());
+        verify(target, never()).sendMessage(anyString());
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/commands/WildCommandSafetyCheckTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/WildCommandSafetyCheckTest.java
@@ -1,0 +1,136 @@
+package com.ultikits.plugins.essentials.commands;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link WildCommand#wildTeleport}'s five safety-check rejection directions and its
+ * retry-loop exhaustion path -- the existing {@code WildCommandTest} only ever exercises the
+ * "everything is safe" success path and the disabled-feature path, leaving every rejection
+ * reason (and the give-up-after-10-attempts path it always leads to here) untested.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("WildCommand safety-check rejection Tests")
+class WildCommandSafetyCheckTest {
+
+    private WildCommand command;
+    private EssentialsConfig config;
+    private Player player;
+    private World world;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+        config = new EssentialsConfig();
+        command = new WildCommand(config);
+        EssentialsTestHelper.setField(command, "plugin", EssentialsTestHelper.getMockPlugin());
+        player = EssentialsTestHelper.createMockPlayer("TestPlayer", UUID.randomUUID());
+        world = player.getWorld();
+
+        Location playerLoc = new Location(world, 0, 64, 0);
+        when(player.getLocation()).thenReturn(playerLoc);
+        when(world.getHighestBlockYAt(anyInt(), anyInt())).thenReturn(64);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    /**
+     * Every candidate location resolves to the same feet/head/ground block mocks regardless of
+     * its (randomized) coordinates, so the outcome is deterministic across all 10 retry attempts.
+     */
+    private void stubUniformBlocks(Material feetType, Material headType, Material groundType) {
+        Block feet = mock(Block.class);
+        Block head = mock(Block.class);
+        Block ground = mock(Block.class);
+        when(feet.getType()).thenReturn(feetType);
+        when(head.getType()).thenReturn(headType);
+        when(ground.getType()).thenReturn(groundType);
+        when(feet.getRelative(0, 1, 0)).thenReturn(head);
+        when(feet.getRelative(0, -1, 0)).thenReturn(ground);
+        when(world.getBlockAt(any(Location.class))).thenReturn(feet);
+    }
+
+    private void assertNeverTeleportsAndReportsFailure() {
+        verify(player, never()).teleport(any(Location.class));
+        verify(player).sendMessage(contains("未能找到安全位置"));
+    }
+
+    @Test
+    @DisplayName("A solid feet block is never a safe teleport target")
+    void solidFeetBlockIsRejected() {
+        stubUniformBlocks(Material.STONE, Material.AIR, Material.GRASS_BLOCK);
+
+        command.wildTeleport(player);
+
+        assertNeverTeleportsAndReportsFailure();
+    }
+
+    @Test
+    @DisplayName("A solid head block (feet clear) is never a safe teleport target")
+    void solidHeadBlockIsRejected() {
+        stubUniformBlocks(Material.AIR, Material.STONE, Material.GRASS_BLOCK);
+
+        command.wildTeleport(player);
+
+        assertNeverTeleportsAndReportsFailure();
+    }
+
+    @Test
+    @DisplayName("A non-solid ground block is never a safe teleport target")
+    void nonSolidGroundIsRejected() {
+        stubUniformBlocks(Material.AIR, Material.AIR, Material.AIR);
+
+        command.wildTeleport(player);
+
+        assertNeverTeleportsAndReportsFailure();
+    }
+
+    @Test
+    @DisplayName("Lava as the ground block is never a safe teleport target")
+    void lavaGroundIsRejected() {
+        stubUniformBlocks(Material.AIR, Material.AIR, Material.LAVA);
+
+        command.wildTeleport(player);
+
+        assertNeverTeleportsAndReportsFailure();
+    }
+
+    @Test
+    @DisplayName("Water as the ground block is never a safe teleport target")
+    void waterGroundIsRejected() {
+        stubUniformBlocks(Material.AIR, Material.AIR, Material.WATER);
+
+        command.wildTeleport(player);
+
+        assertNeverTeleportsAndReportsFailure();
+    }
+
+    @Test
+    @DisplayName("After 10 failed attempts, the player is told no safe location was found and is never teleported")
+    void exhaustingAllAttemptsNeverTeleports() {
+        stubUniformBlocks(Material.STONE, Material.AIR, Material.GRASS_BLOCK);
+
+        command.wildTeleport(player);
+
+        // getBlockAt is called once per attempt inside the retry loop
+        verify(world, times(10)).getBlockAt(any(Location.class));
+        assertNeverTeleportsAndReportsFailure();
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/listener/DeathPunishListenerBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/DeathPunishListenerBehaviorTest.java
@@ -1,0 +1,166 @@
+package com.ultikits.plugins.essentials.listener;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link DeathPunishListener}'s item-drop selection ({@code processItemDrop}) -- a
+ * decision surface the existing {@code DeathPunishListenerMockitoTest} never reaches at all
+ * (none of its tests enable {@code deathPunishItemDropEnabled}).
+ * <p>
+ * Note on {@code keepOtherItems}: reading the source is required here, because the flag's name
+ * is the opposite of its effect. When {@code true}, the method filters {@code drops} down to
+ * ONLY the items selected by the drop-chance roll (the comment directly above that line reads
+ * "Keep only dropped items (remove others)"); when {@code false}, {@code retainAll} is never
+ * called and the original drop list is left completely untouched. The tests below assert that
+ * actual, source-verified behaviour rather than the name's intuitive-but-wrong reading.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("DeathPunishListener item-drop selection Tests")
+class DeathPunishListenerBehaviorTest {
+
+    private DeathPunishListener listener;
+    private EssentialsConfig config;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        listener = new DeathPunishListener();
+        config = new EssentialsConfig();
+        EssentialsTestHelper.setField(listener, "config", config);
+
+        config.setDeathPunishEnabled(true);
+        config.setDeathPunishWorldWhitelist(Collections.emptyList());
+        config.setDeathPunishMoneyEnabled(false);
+        config.setDeathPunishExpEnabled(false);
+        config.setDeathPunishCommandEnabled(false);
+        config.setDeathPunishItemDropEnabled(true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private Player createDeathPlayer() {
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        org.bukkit.World world = EssentialsTestHelper.createMockWorld("world");
+        lenient().when(player.getWorld()).thenReturn(world);
+        lenient().when(player.hasPermission("ultiessentials.deathpunish.bypass")).thenReturn(false);
+        lenient().when(player.getTotalExperience()).thenReturn(0);
+        return player;
+    }
+
+    private ItemStack mockItem(org.bukkit.Material material) {
+        ItemStack item = mock(ItemStack.class);
+        lenient().when(item.getType()).thenReturn(material);
+        return item;
+    }
+
+    @Nested
+    @DisplayName("Whitelist and drop-chance selection")
+    class SelectionTests {
+
+        @Test
+        @DisplayName("A whitelisted item type is never counted toward the drop count")
+        void whitelistedItemIsSkipped() {
+            config.setDeathPunishItemDropChance(100.0); // would always be selected if not whitelisted
+            config.setDeathPunishItemWhitelist(Collections.singletonList("DIAMOND"));
+            config.setDeathPunishKeepOtherItems(false);
+
+            Player player = createDeathPlayer();
+            List<ItemStack> drops = new ArrayList<>(Collections.singletonList(mockItem(org.bukkit.Material.DIAMOND)));
+            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+
+            listener.onPlayerDeath(event);
+
+            // whitelisted item never enters toDrop, so the message never mentions any drop count
+            verify(player, never()).sendMessage(contains("物品掉落"));
+        }
+
+        @Test
+        @DisplayName("A non-whitelisted item within the drop chance is counted and reported")
+        void nonWhitelistedItemWithinChanceIsCounted() {
+            config.setDeathPunishItemDropChance(100.0); // guarantee the "within chance" branch
+            config.setDeathPunishItemWhitelist(Collections.emptyList());
+            config.setDeathPunishKeepOtherItems(false);
+
+            Player player = createDeathPlayer();
+            List<ItemStack> drops = new ArrayList<>(Collections.singletonList(mockItem(org.bukkit.Material.STONE)));
+            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+
+            listener.onPlayerDeath(event);
+
+            verify(player).sendMessage(contains("1件物品掉落"));
+        }
+
+        @Test
+        @DisplayName("A drop chance of zero never counts any non-whitelisted item")
+        void zeroChanceNeverCounts() {
+            config.setDeathPunishItemDropChance(0.0); // guarantee the "outside chance" branch
+            config.setDeathPunishItemWhitelist(Collections.emptyList());
+            config.setDeathPunishKeepOtherItems(false);
+
+            Player player = createDeathPlayer();
+            List<ItemStack> drops = new ArrayList<>(Collections.singletonList(mockItem(org.bukkit.Material.STONE)));
+            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+
+            listener.onPlayerDeath(event);
+
+            verify(player, never()).sendMessage(contains("物品掉落"));
+        }
+    }
+
+    @Nested
+    @DisplayName("keepOtherItems drop-list mutation")
+    class KeepOtherItemsTests {
+
+        @Test
+        @DisplayName("keepOtherItems=false leaves the original drop list completely untouched")
+        void keepOtherItemsFalseLeavesListUntouched() {
+            config.setDeathPunishItemDropChance(0.0); // this item is never selected into toDrop
+            config.setDeathPunishItemWhitelist(Collections.emptyList());
+            config.setDeathPunishKeepOtherItems(false);
+
+            Player player = createDeathPlayer();
+            ItemStack notSelected = mockItem(org.bukkit.Material.STONE);
+            List<ItemStack> drops = new ArrayList<>(Collections.singletonList(notSelected));
+            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+
+            listener.onPlayerDeath(event);
+
+            // retainAll is never called: the un-selected item stays in the drop list
+            assertThat(event.getDrops()).contains(notSelected);
+        }
+
+        @Test
+        @DisplayName("keepOtherItems=true filters the drop list down to only the selected items")
+        void keepOtherItemsTrueFiltersToSelectedOnly() {
+            config.setDeathPunishItemDropChance(0.0); // this item is never selected into toDrop
+            config.setDeathPunishItemWhitelist(Collections.emptyList());
+            config.setDeathPunishKeepOtherItems(true);
+
+            Player player = createDeathPlayer();
+            ItemStack notSelected = mockItem(org.bukkit.Material.STONE);
+            List<ItemStack> drops = new ArrayList<>(Collections.singletonList(notSelected));
+            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+
+            listener.onPlayerDeath(event);
+
+            // retainAll(toDrop) removes the un-selected item, since toDrop is empty
+            assertThat(event.getDrops()).doesNotContain(notSelected);
+        }
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/BanServiceFilterCoverageTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/BanServiceFilterCoverageTest.java
@@ -1,0 +1,147 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.entity.BanData;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.interfaces.Query;
+import org.junit.jupiter.api.*;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the two directions of BanService's own "an active, non-expired ban" domain rule
+ * ({@code b.isActive() && !b.hasExpired()}) that {@code BanServiceMockitoTest} does not reach for
+ * every call site: {@code unbanPlayerByName}, {@code unbanIp}, and {@code getActiveIpBan} are
+ * never tested against an active-but-expired ban record there, and {@code getActiveBan} is never
+ * tested against an inactive one. Each of the five call sites shares the identical lambda body,
+ * but JaCoCo's branch counter is per call site, not per shared predicate -- this class closes
+ * exactly the outcomes the existing suite leaves untested at each site.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("BanService active-ban filter coverage Tests")
+class BanServiceFilterCoverageTest {
+
+    private BanService banService;
+
+    @SuppressWarnings("unchecked")
+    private final DataOperator<BanData> banOperator = mock(DataOperator.class);
+
+    @SuppressWarnings("unchecked")
+    private final Query<BanData> query = mock(Query.class);
+
+    private UUID playerUuid;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        EssentialsConfig config = new EssentialsConfig();
+        banService = new BanService();
+        EssentialsTestHelper.setField(banService, "config", config);
+        EssentialsTestHelper.setField(banService, "banOperator", banOperator);
+
+        playerUuid = UUID.randomUUID();
+
+        reset(banOperator, query);
+        when(banOperator.query()).thenReturn(query);
+        when(query.where(anyString())).thenReturn(query);
+        when(query.eq(any())).thenReturn(query);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private BanData expiredButStillMarkedActive(String ip) {
+        return BanData.builder()
+                .uuid(UUID.randomUUID())
+                .playerUuid(playerUuid.toString())
+                .playerName("TestPlayer")
+                .reason("stale")
+                .bannedByName("Admin")
+                .banTime(System.currentTimeMillis() - 200000)
+                .expireTime(System.currentTimeMillis() - 100000)
+                .active(true)
+                .ipAddress(ip)
+                .build();
+    }
+
+    private BanData inactive() {
+        return BanData.builder()
+                .uuid(UUID.randomUUID())
+                .playerUuid(playerUuid.toString())
+                .playerName("TestPlayer")
+                .reason("was banned")
+                .bannedByName("Admin")
+                .banTime(System.currentTimeMillis())
+                .expireTime(-1)
+                .active(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("unbanPlayer does not unban a record that is active but already expired")
+    void unbanPlayerIgnoresExpiredRecord() throws Exception {
+        when(query.list()).thenReturn(
+                new java.util.ArrayList<>(Collections.singletonList(expiredButStillMarkedActive(null))));
+
+        boolean result = banService.unbanPlayer(playerUuid);
+
+        assertThat(result).isFalse();
+        verify(banOperator, never()).update(any(BanData.class));
+    }
+
+    @Test
+    @DisplayName("getActiveBan does not treat an inactive ban record as an active ban")
+    void getActiveBanIgnoresInactiveRecord() {
+        when(query.list()).thenReturn(Collections.singletonList(inactive()));
+
+        BanData result = banService.getActiveBan(playerUuid);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("unbanPlayerByName does not unban a record that is active but already expired")
+    void unbanPlayerByNameIgnoresExpiredRecord() throws Exception {
+        when(query.list()).thenReturn(
+                new java.util.ArrayList<>(Collections.singletonList(expiredButStillMarkedActive(null))));
+
+        boolean result = banService.unbanPlayerByName("TestPlayer");
+
+        assertThat(result).isFalse();
+        verify(banOperator, never()).update(any(BanData.class));
+    }
+
+    @Test
+    @DisplayName("unbanIp does not unban a record that is active but already expired")
+    void unbanIpIgnoresExpiredRecord() throws Exception {
+        when(query.list()).thenReturn(
+                new java.util.ArrayList<>(Collections.singletonList(expiredButStillMarkedActive("10.0.0.5"))));
+
+        boolean result = banService.unbanIp("10.0.0.5");
+
+        assertThat(result).isFalse();
+        verify(banOperator, never()).update(any(BanData.class));
+    }
+
+    @Test
+    @DisplayName("getActiveIpBan does not return a record that is active but already expired")
+    void getActiveIpBanIgnoresExpiredRecord() {
+        when(query.list()).thenReturn(Collections.singletonList(expiredButStillMarkedActive("10.0.0.6")));
+
+        BanData result = banService.getActiveIpBan("10.0.0.6");
+
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/ChestLockServiceDoubleChestTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/ChestLockServiceDoubleChestTest.java
@@ -1,0 +1,362 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.entity.ChestLockData;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import com.ultikits.ultitools.interfaces.DataOperator;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Chest;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.junit.jupiter.api.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link ChestLockService}'s double-chest propagation behaviour:
+ * locking or unlocking one half of a double chest also locks/unlocks the
+ * other half.
+ * <p>
+ * The existing {@code ChestLockServiceMockitoTest} deliberately configures every mock
+ * block's {@code getState()} to return a non-{@code Chest} {@code BlockState}
+ * ("prevents double-chest path", per that file's own {@code createMockBlock} comment),
+ * so {@code lockDoubleChestOther}/{@code unlockDoubleChestOther}'s decision surface —
+ * chest-type guard, chest-state guard, double-chest-holder guard, left/right side
+ * selection, and the already-locked/already-unlocked guard on the other half — is
+ * never exercised there. This class exercises exactly that surface.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("ChestLockService double-chest propagation Tests")
+class ChestLockServiceDoubleChestTest {
+
+    private ChestLockService service;
+    private EssentialsConfig config;
+
+    @SuppressWarnings("unchecked")
+    private final DataOperator<ChestLockData> lockOperator = mock(DataOperator.class);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        config = new EssentialsConfig();
+
+        service = new ChestLockService();
+        EssentialsTestHelper.setField(service, "config", config);
+        EssentialsTestHelper.setField(service, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(service, "lockOperator", lockOperator);
+
+        reset(lockOperator);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, ChestLockData> cache() throws Exception {
+        return (Map<String, ChestLockData>) EssentialsTestHelper.getField(service, "lockCache");
+    }
+
+    /** A single, non-double chest (or non-chest lockable) block. State is a plain BlockState. */
+    private Block createNonDoubleChestBlock(Material material, World world, int x, int y, int z) {
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(material);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getX()).thenReturn(x);
+        when(block.getY()).thenReturn(y);
+        when(block.getZ()).thenReturn(z);
+        Location loc = new Location(world, x, y, z);
+        when(block.getLocation()).thenReturn(loc);
+        BlockState state = mock(BlockState.class);
+        when(block.getState()).thenReturn(state);
+        return block;
+    }
+
+    /** A chest block whose state IS a Chest, but whose inventory holder is a single (non-double) chest. */
+    private Block createSingleChestBlockWithChestState(World world, int x, int y, int z) {
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.CHEST);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getX()).thenReturn(x);
+        when(block.getY()).thenReturn(y);
+        when(block.getZ()).thenReturn(z);
+        Location loc = new Location(world, x, y, z);
+        when(block.getLocation()).thenReturn(loc);
+
+        Chest chestState = mock(Chest.class);
+        Inventory inventory = mock(Inventory.class);
+        when(chestState.getInventory()).thenReturn(inventory);
+        InventoryHolder singleHolder = mock(InventoryHolder.class);
+        when(inventory.getHolder()).thenReturn(singleHolder);
+        when(block.getState()).thenReturn(chestState);
+        return block;
+    }
+
+    /**
+     * A chest block that is one half of a double chest. {@code isLeftSide} selects which of
+     * {@code doubleChest.getLeftSide()}/{@code getRightSide()} resolves to this block's own
+     * location (matching the ternary's true branch) vs. the other half's location.
+     */
+    private Block createDoubleChestBlock(World world, int x, int y, int z, boolean isLeftSide, Location otherLoc) {
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.CHEST);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getX()).thenReturn(x);
+        when(block.getY()).thenReturn(y);
+        when(block.getZ()).thenReturn(z);
+        Location loc = new Location(world, x, y, z);
+        when(block.getLocation()).thenReturn(loc);
+
+        Chest chestState = mock(Chest.class);
+        Inventory inventory = mock(Inventory.class);
+        when(chestState.getInventory()).thenReturn(inventory);
+
+        DoubleChest doubleChest = mock(DoubleChest.class);
+        when(inventory.getHolder()).thenReturn(doubleChest);
+
+        Chest leftChest = mock(Chest.class);
+        Chest rightChest = mock(Chest.class);
+        if (isLeftSide) {
+            when(leftChest.getLocation()).thenReturn(loc);
+            when(rightChest.getLocation()).thenReturn(otherLoc);
+        } else {
+            when(leftChest.getLocation()).thenReturn(otherLoc);
+            when(rightChest.getLocation()).thenReturn(loc);
+        }
+        when(doubleChest.getLeftSide()).thenReturn(leftChest);
+        when(doubleChest.getRightSide()).thenReturn(rightChest);
+
+        when(block.getState()).thenReturn(chestState);
+        return block;
+    }
+
+    @Nested
+    @DisplayName("lockDoubleChestOther (reached via lockBlock)")
+    class LockDoubleChestOtherTests {
+
+        @Test
+        @DisplayName("locking a barrel (lockable, but not CHEST/TRAPPED_CHEST) never attempts to lock a second block")
+        void barrelDoesNotPropagateLock() {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            Block block = createNonDoubleChestBlock(Material.BARREL, world, 1, 64, 1);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            ChestLockService.LockResult result = service.lockBlock(block, player);
+
+            assertThat(result).isEqualTo(ChestLockService.LockResult.SUCCESS);
+            verify(lockOperator, times(1)).insert(any(ChestLockData.class));
+        }
+
+        @Test
+        @DisplayName("locking a chest that is not part of a double chest never attempts to lock a second block")
+        void singleChestDoesNotPropagateLock() {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            Block block = createSingleChestBlockWithChestState(world, 1, 64, 1);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            ChestLockService.LockResult result = service.lockBlock(block, player);
+
+            assertThat(result).isEqualTo(ChestLockService.LockResult.SUCCESS);
+            verify(lockOperator, times(1)).insert(any(ChestLockData.class));
+        }
+
+        @Test
+        @DisplayName("locking the left half of a double chest also locks the right half")
+        void locksRightHalfWhenLockingLeftHalf() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            Location rightLoc = new Location(world, 2, 64, 1);
+            Block leftBlock = createDoubleChestBlock(world, 1, 64, 1, true, rightLoc);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            ChestLockService.LockResult result = service.lockBlock(leftBlock, player);
+
+            assertThat(result).isEqualTo(ChestLockService.LockResult.SUCCESS);
+            verify(lockOperator, times(2)).insert(any(ChestLockData.class));
+            assertThat(service.isLocked(rightLoc)).isTrue();
+        }
+
+        @Test
+        @DisplayName("locking the right half of a double chest also locks the left half")
+        void locksLeftHalfWhenLockingRightHalf() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            Location leftLoc = new Location(world, 1, 64, 1);
+            Block rightBlock = createDoubleChestBlock(world, 2, 64, 1, false, leftLoc);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            ChestLockService.LockResult result = service.lockBlock(rightBlock, player);
+
+            assertThat(result).isEqualTo(ChestLockService.LockResult.SUCCESS);
+            verify(lockOperator, times(2)).insert(any(ChestLockData.class));
+            assertThat(service.isLocked(leftLoc)).isTrue();
+        }
+
+        @Test
+        @DisplayName("locking a double chest whose other half is already locked does not create a duplicate lock")
+        void doesNotDuplicateLockWhenOtherHalfAlreadyLocked() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            Location rightLoc = new Location(world, 2, 64, 1);
+            Block leftBlock = createDoubleChestBlock(world, 1, 64, 1, true, rightLoc);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            ChestLockData existingOtherLock = ChestLockData.builder()
+                    .uuid(UUID.randomUUID())
+                    .world("world").x(2).y(64).z(1)
+                    .ownerUuid(UUID.randomUUID().toString())
+                    .ownerName("Other")
+                    .build();
+            cache().put(existingOtherLock.getLocationKey(), existingOtherLock);
+
+            ChestLockService.LockResult result = service.lockBlock(leftBlock, player);
+
+            assertThat(result).isEqualTo(ChestLockService.LockResult.SUCCESS);
+            // Exactly one insert -- for the block actually locked. The already-locked other
+            // half must not receive a second, duplicate insert.
+            verify(lockOperator, times(1)).insert(any(ChestLockData.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("unlockDoubleChestOther (reached via unlockBlock)")
+    class UnlockDoubleChestOtherTests {
+
+        private void seedLock(Location loc, UUID owner) throws Exception {
+            ChestLockData lock = ChestLockData.builder()
+                    .uuid(UUID.randomUUID())
+                    .world(loc.getWorld().getName())
+                    .x(loc.getBlockX()).y(loc.getBlockY()).z(loc.getBlockZ())
+                    .ownerUuid(owner.toString())
+                    .ownerName("Steve")
+                    .build();
+            cache().put(lock.getLocationKey(), lock);
+        }
+
+        @Test
+        @DisplayName("unlocking a barrel never attempts to unlock a second block")
+        void barrelDoesNotPropagateUnlock() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            UUID playerUuid = UUID.randomUUID();
+            Location loc = new Location(world, 1, 64, 1);
+            seedLock(loc, playerUuid);
+            Block block = createNonDoubleChestBlock(Material.BARREL, world, 1, 64, 1);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", playerUuid);
+
+            ChestLockService.UnlockResult result = service.unlockBlock(block, player);
+
+            assertThat(result).isEqualTo(ChestLockService.UnlockResult.SUCCESS);
+            verify(lockOperator, times(1)).delById(any());
+        }
+
+        @Test
+        @DisplayName("unlocking a chest that is not part of a double chest never attempts to unlock a second block")
+        void singleChestDoesNotPropagateUnlock() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            UUID playerUuid = UUID.randomUUID();
+            Location loc = new Location(world, 1, 64, 1);
+            seedLock(loc, playerUuid);
+            Block block = createSingleChestBlockWithChestState(world, 1, 64, 1);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", playerUuid);
+
+            ChestLockService.UnlockResult result = service.unlockBlock(block, player);
+
+            assertThat(result).isEqualTo(ChestLockService.UnlockResult.SUCCESS);
+            verify(lockOperator, times(1)).delById(any());
+        }
+
+        @Test
+        @DisplayName("unlocking the left half of a double chest also unlocks the right half")
+        void unlocksRightHalfWhenUnlockingLeftHalf() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            UUID playerUuid = UUID.randomUUID();
+            Location leftLoc = new Location(world, 1, 64, 1);
+            Location rightLoc = new Location(world, 2, 64, 1);
+            seedLock(leftLoc, playerUuid);
+            seedLock(rightLoc, playerUuid);
+            Block leftBlock = createDoubleChestBlock(world, 1, 64, 1, true, rightLoc);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", playerUuid);
+
+            ChestLockService.UnlockResult result = service.unlockBlock(leftBlock, player);
+
+            assertThat(result).isEqualTo(ChestLockService.UnlockResult.SUCCESS);
+            verify(lockOperator, times(2)).delById(any());
+            assertThat(service.isLocked(rightLoc)).isFalse();
+        }
+
+        @Test
+        @DisplayName("unlocking the right half of a double chest also unlocks the left half")
+        void unlocksLeftHalfWhenUnlockingRightHalf() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            UUID playerUuid = UUID.randomUUID();
+            Location leftLoc = new Location(world, 1, 64, 1);
+            Location rightLoc = new Location(world, 2, 64, 1);
+            seedLock(leftLoc, playerUuid);
+            seedLock(rightLoc, playerUuid);
+            Block rightBlock = createDoubleChestBlock(world, 2, 64, 1, false, leftLoc);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", playerUuid);
+
+            ChestLockService.UnlockResult result = service.unlockBlock(rightBlock, player);
+
+            assertThat(result).isEqualTo(ChestLockService.UnlockResult.SUCCESS);
+            verify(lockOperator, times(2)).delById(any());
+            assertThat(service.isLocked(leftLoc)).isFalse();
+        }
+
+        @Test
+        @DisplayName("unlocking a double chest whose other half has no lock does not attempt a second delete")
+        void doesNotDeleteWhenOtherHalfNotLocked() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            UUID playerUuid = UUID.randomUUID();
+            Location leftLoc = new Location(world, 1, 64, 1);
+            Location rightLoc = new Location(world, 2, 64, 1);
+            seedLock(leftLoc, playerUuid); // only this half is locked
+            Block leftBlock = createDoubleChestBlock(world, 1, 64, 1, true, rightLoc);
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", playerUuid);
+
+            ChestLockService.UnlockResult result = service.unlockBlock(leftBlock, player);
+
+            assertThat(result).isEqualTo(ChestLockService.UnlockResult.SUCCESS);
+            // Exactly one delete -- for the block actually unlocked. The already-unlocked
+            // other half must not trigger a second, spurious delete.
+            verify(lockOperator, times(1)).delById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("canAccess admin bypass")
+    class CanAccessAdminBypassTests {
+
+        @Test
+        @DisplayName("admin without bypass config enabled cannot access another player's locked chest, even with the admin permission node")
+        void adminCannotAccessWhenBypassConfigDisabled() throws Exception {
+            World world = EssentialsTestHelper.createMockWorld("world");
+            config.setChestLockAdminBypass(false);
+
+            ChestLockData lock = ChestLockData.builder()
+                    .uuid(UUID.randomUUID())
+                    .world("world").x(100).y(64).z(200)
+                    .ownerUuid(UUID.randomUUID().toString())
+                    .build();
+            cache().put(lock.getLocationKey(), lock);
+
+            Location loc = new Location(world, 100, 64, 200);
+            Player admin = EssentialsTestHelper.createMockPlayer("Admin", UUID.randomUUID());
+            when(admin.hasPermission("ultiessentials.lock.admin")).thenReturn(true);
+
+            assertThat(service.canAccess(loc, admin)).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/HomeServiceTeleportBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/HomeServiceTeleportBehaviorTest.java
@@ -1,0 +1,133 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.entity.HomeData;
+import com.ultikits.plugins.essentials.enums.TeleportResult;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.interfaces.Query;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the two {@code teleportToHome} directions {@code HomeServiceMockitoTest} never reaches:
+ * a home that exists but whose world is no longer registered (WORLD_NOT_FOUND), and a home that
+ * resolves successfully -- which is also the only place the warmup-skip permission decision is
+ * exercised.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("HomeService teleportToHome world-resolution Tests")
+class HomeServiceTeleportBehaviorTest {
+
+    private HomeService homeService;
+    private EssentialsConfig config;
+    private TeleportService teleportService;
+
+    @SuppressWarnings("unchecked")
+    private final DataOperator<HomeData> homeOperator = mock(DataOperator.class);
+
+    @SuppressWarnings("unchecked")
+    private final Query<HomeData> query = mock(Query.class);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        config = new EssentialsConfig();
+        teleportService = mock(TeleportService.class);
+
+        homeService = new HomeService();
+        EssentialsTestHelper.setField(homeService, "config", config);
+        EssentialsTestHelper.setField(homeService, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(homeService, "homeOperator", homeOperator);
+        EssentialsTestHelper.setField(homeService, "teleportService", teleportService);
+
+        reset(homeOperator, query);
+        when(homeOperator.query()).thenReturn(query);
+        when(query.where(anyString())).thenReturn(query);
+        when(query.eq(any())).thenReturn(query);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private HomeData homeIn(String worldName) {
+        return HomeData.builder()
+                .uuid(UUID.randomUUID())
+                .playerUuid(UUID.randomUUID().toString())
+                .name("home")
+                .world(worldName)
+                .x(1).y(64).z(1)
+                .yaw(0).pitch(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("A home whose world is no longer registered on the server resolves to WORLD_NOT_FOUND")
+    void unregisteredWorldResolvesToWorldNotFound() {
+        when(query.first()).thenReturn(homeIn("deleted_world"));
+        Server server = Bukkit.getServer();
+        when(server.getWorld("deleted_world")).thenReturn(null);
+
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+        TeleportResult result = homeService.teleportToHome(player, "home");
+
+        assertThat(result).isEqualTo(TeleportResult.WORLD_NOT_FOUND);
+        verify(teleportService, never()).teleport(any(), any(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("A home with a live world delegates to TeleportService with the full configured warmup")
+    void resolvedHomeDelegatesWithFullWarmup() {
+        when(query.first()).thenReturn(homeIn("world"));
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Server server = Bukkit.getServer();
+        when(server.getWorld("world")).thenReturn(world);
+        config.setHomeTeleportWarmup(10);
+
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.hasPermission("ultiessentials.home.nowarmup")).thenReturn(false);
+        when(teleportService.teleport(eq(player), any(Location.class), eq(10), anyBoolean()))
+                .thenReturn(TeleportResult.WARMUP_STARTED);
+
+        TeleportResult result = homeService.teleportToHome(player, "home");
+
+        assertThat(result).isEqualTo(TeleportResult.WARMUP_STARTED);
+        verify(teleportService).teleport(eq(player), any(Location.class), eq(10), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("The no-warmup permission skips the configured warmup entirely")
+    void noWarmupPermissionSkipsConfiguredWarmup() {
+        when(query.first()).thenReturn(homeIn("world"));
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Server server = Bukkit.getServer();
+        when(server.getWorld("world")).thenReturn(world);
+        config.setHomeTeleportWarmup(10);
+
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.hasPermission("ultiessentials.home.nowarmup")).thenReturn(true);
+        when(teleportService.teleport(eq(player), any(Location.class), eq(0), anyBoolean()))
+                .thenReturn(TeleportResult.SUCCESS);
+
+        TeleportResult result = homeService.teleportToHome(player, "home");
+
+        assertThat(result).isEqualTo(TeleportResult.SUCCESS);
+        verify(teleportService).teleport(eq(player), any(Location.class), eq(0), anyBoolean());
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/NamePrefixServiceBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/NamePrefixServiceBehaviorTest.java
@@ -1,0 +1,145 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
+import org.bukkit.scoreboard.Team;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link NamePrefixService} decisions the existing {@code NamePrefixServiceMockitoTest}
+ * does not reach: {@code init()} is never called there (fields are injected directly via
+ * reflection), {@code parsePlaceholders}'s PlaceholderAPI-present branch is never taken, and the
+ * suffix-truncation path mirrors the existing prefix-truncation test but is itself untested.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("NamePrefixService init/parsePlaceholders/suffix-truncation Tests")
+class NamePrefixServiceBehaviorTest {
+
+    private NamePrefixService service;
+    private EssentialsConfig config;
+    private Scoreboard mainScoreboard;
+    private BukkitScheduler scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        config = new EssentialsConfig();
+
+        ScoreboardManager scoreboardManager = mock(ScoreboardManager.class);
+        mainScoreboard = mock(Scoreboard.class);
+        when(scoreboardManager.getMainScoreboard()).thenReturn(mainScoreboard);
+        when(EssentialsTestHelper.getMockServer().getScoreboardManager()).thenReturn(scoreboardManager);
+
+        scheduler = EssentialsTestHelper.getMockServer().getScheduler();
+        BukkitTask mockTask = mock(BukkitTask.class);
+        lenient().when(scheduler.runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong()))
+                .thenReturn(mockTask);
+
+        config.setNamePrefixEnabled(true);
+
+        service = new NamePrefixService();
+        EssentialsTestHelper.setField(service, "config", config);
+        EssentialsTestHelper.setField(service, "scoreboard", mainScoreboard);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    @Nested
+    @DisplayName("init")
+    class InitTests {
+
+        @Test
+        @DisplayName("A disabled feature never starts the update task")
+        void disabledFeatureNeverStartsUpdateTask() {
+            config.setNamePrefixEnabled(false);
+
+            service.init();
+
+            verify(scheduler, never()).runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("An enabled feature starts the update task")
+        void enabledFeatureStartsUpdateTask() {
+            when(EssentialsTestHelper.getMockServer().getPluginManager().getPlugin("UltiTools"))
+                    .thenReturn(mock(Plugin.class));
+            config.setNamePrefixEnabled(true);
+
+            service.init();
+
+            verify(scheduler, times(1)).runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("parsePlaceholders (via updatePlayer)")
+    class ParsePlaceholdersTests {
+
+        @Test
+        @DisplayName("When PlaceholderAPI is installed, the prefix format is delegated to it")
+        void delegatesToPlaceholderApiWhenInstalled() {
+            Team team = mock(Team.class);
+            when(mainScoreboard.getTeam(anyString())).thenReturn(null);
+            when(mainScoreboard.registerNewTeam(anyString())).thenReturn(team);
+            when(team.hasEntry(anyString())).thenReturn(false);
+            config.setNamePrefixFormat("%player_name%'s prefix");
+
+            PluginManager pluginManager = EssentialsTestHelper.getMockServer().getPluginManager();
+            when(pluginManager.getPlugin("PlaceholderAPI")).thenReturn(mock(Plugin.class));
+
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            try (MockedStatic<PlaceholderAPI> papi = mockStatic(PlaceholderAPI.class)) {
+                papi.when(() -> PlaceholderAPI.setPlaceholders(eq(player), anyString()))
+                        .thenReturn("PAPI-RESOLVED");
+
+                service.updatePlayer(player);
+
+                papi.verify(() -> PlaceholderAPI.setPlaceholders(eq(player), anyString()), atLeastOnce());
+                verify(team).setPrefix("PAPI-RESOLVED");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Suffix truncation")
+    class SuffixTruncationTests {
+
+        @Test
+        @DisplayName("A suffix longer than 64 characters is truncated to 64")
+        void longSuffixIsTruncated() {
+            Team team = mock(Team.class);
+            when(mainScoreboard.getTeam(anyString())).thenReturn(null);
+            when(mainScoreboard.registerNewTeam(anyString())).thenReturn(team);
+            when(team.hasEntry(anyString())).thenReturn(false);
+            config.setNameSuffixFormat("b".repeat(100));
+
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            service.updatePlayer(player);
+
+            verify(team).setSuffix(argThat(suffix -> suffix.length() <= 64));
+        }
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/NamePrefixServiceBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/NamePrefixServiceBehaviorTest.java
@@ -139,7 +139,11 @@ class NamePrefixServiceBehaviorTest {
 
             service.updatePlayer(player);
 
-            verify(team).setSuffix(argThat(suffix -> suffix.length() <= 64));
+            // Exact length (and exact value), not "at most 64" -- NamePrefixService.java does an
+            // exact substring(0, 64), so any truncation short of 64 would still satisfy a "<= 64"
+            // check while visibly breaking the feature.
+            String expected = "b".repeat(100).substring(0, 64);
+            verify(team).setSuffix(argThat(suffix -> suffix.length() == 64 && suffix.equals(expected)));
         }
     }
 }

--- a/src/test/java/com/ultikits/plugins/essentials/service/ScoreboardServiceBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/ScoreboardServiceBehaviorTest.java
@@ -146,7 +146,11 @@ class ScoreboardServiceBehaviorTest {
 
             ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
             verify(mockObjective).getScore(captor.capture());
-            assertThat(captor.getValue()).hasSizeLessThanOrEqualTo(40);
+            // Exact length (and exact value), not "at most 40" -- ScoreboardService.java does an
+            // exact substring(0, 40), so any truncation short of 40 would still satisfy a "<= 40"
+            // check while visibly breaking the feature. The appended ChatColor code lands past
+            // position 40, so the expected value is simply the original line's first 40 chars.
+            assertThat(captor.getValue()).hasSize(40).isEqualTo(longLine.substring(0, 40));
         }
     }
 

--- a/src/test/java/com/ultikits/plugins/essentials/service/ScoreboardServiceBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/ScoreboardServiceBehaviorTest.java
@@ -1,0 +1,216 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scoreboard.*;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link ScoreboardService}'s decisions not reached by the existing
+ * {@code ScoreboardServiceMockitoTest}: {@code init()} is never called there (the manager field
+ * is injected directly via reflection instead), {@code ensureUnique}'s collision-resolution loop
+ * is never exercised (no test seeds a colliding scoreboard entry), and {@code parsePlaceholders}'
+ * PlaceholderAPI-present branch is never taken (the plugin lookup always returns null there).
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("ScoreboardService init/ensureUnique/parsePlaceholders Tests")
+class ScoreboardServiceBehaviorTest {
+
+    private ScoreboardService service;
+    private EssentialsConfig config;
+    private ScoreboardManager scoreboardManager;
+    private Scoreboard mockScoreboard;
+    private Objective mockObjective;
+    private BukkitScheduler scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        config = new EssentialsConfig();
+
+        scoreboardManager = mock(ScoreboardManager.class);
+        mockScoreboard = mock(Scoreboard.class);
+        when(scoreboardManager.getNewScoreboard()).thenReturn(mockScoreboard);
+
+        mockObjective = mock(Objective.class);
+        Score mockScore = mock(Score.class);
+        when(mockScoreboard.registerNewObjective(anyString(), anyString(), anyString())).thenReturn(mockObjective);
+        when(mockObjective.getScore(anyString())).thenReturn(mockScore);
+        when(mockScoreboard.getEntries()).thenReturn(new HashSet<>());
+
+        when(EssentialsTestHelper.getMockServer().getScoreboardManager()).thenReturn(scoreboardManager);
+
+        scheduler = EssentialsTestHelper.getMockServer().getScheduler();
+        BukkitTask mockTask = mock(BukkitTask.class);
+        lenient().when(scheduler.runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong()))
+                .thenReturn(mockTask);
+
+        service = new ScoreboardService();
+        EssentialsTestHelper.setField(service, "config", config);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    @Nested
+    @DisplayName("init")
+    class InitTests {
+
+        @Test
+        @DisplayName("A null scoreboard manager disables the feature: no update task is ever started")
+        void nullManagerNeverStartsUpdateTask() {
+            when(EssentialsTestHelper.getMockServer().getScoreboardManager()).thenReturn(null);
+            config.setScoreboardEnabled(true);
+
+            service.init();
+
+            verify(scheduler, never()).runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("A present manager with the feature enabled starts the update task")
+        void presentManagerAndEnabledStartsUpdateTask() {
+            when(EssentialsTestHelper.getMockServer().getPluginManager().getPlugin("UltiTools"))
+                    .thenReturn(mock(Plugin.class));
+            config.setScoreboardEnabled(true);
+
+            service.init();
+
+            verify(scheduler, times(1)).runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("A present manager with the feature disabled never starts the update task")
+        void presentManagerAndDisabledNeverStartsUpdateTask() {
+            config.setScoreboardEnabled(false);
+
+            service.init();
+
+            verify(scheduler, never()).runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("ensureUnique (via updateScoreboard)")
+    class EnsureUniqueTests {
+
+        @Test
+        @DisplayName("A colliding line has a ChatColor code appended instead of being overwritten")
+        void collidingLineGetsColorCodeAppended() throws Exception {
+            EssentialsTestHelper.setField(service, "manager", scoreboardManager);
+            config.setScoreboardLines(Collections.singletonList("Same Line"));
+            // The scoreboard already contains the exact line text this update would produce,
+            // forcing the collision-resolution loop to run at least once.
+            when(mockScoreboard.getEntries()).thenReturn(new HashSet<>(Collections.singletonList("Same Line")));
+
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+            service.enableScoreboard(player);
+
+            ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+            verify(mockObjective).getScore(captor.capture());
+            assertThat(captor.getValue()).isNotEqualTo("Same Line");
+            assertThat(captor.getValue()).startsWith("Same Line");
+        }
+
+        @Test
+        @DisplayName("A resolved line longer than 40 characters is truncated to 40")
+        void resolvedLineIsTruncatedAt40Characters() throws Exception {
+            EssentialsTestHelper.setField(service, "manager", scoreboardManager);
+            String longLine = "This line is exactly long enough to exceed forty characters";
+            config.setScoreboardLines(Collections.singletonList(longLine));
+            // Force at least one collision-resolution pass, appending a color code that pushes
+            // the already-long line over the 40-character limit.
+            when(mockScoreboard.getEntries()).thenReturn(new HashSet<>(Collections.singletonList(longLine)));
+
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+            service.enableScoreboard(player);
+
+            ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+            verify(mockObjective).getScore(captor.capture());
+            assertThat(captor.getValue()).hasSizeLessThanOrEqualTo(40);
+        }
+    }
+
+    @Nested
+    @DisplayName("parsePlaceholders")
+    class ParsePlaceholdersTests {
+
+        @Test
+        @DisplayName("When PlaceholderAPI is installed, placeholders are delegated to it instead of the fallback replacer")
+        void delegatesToPlaceholderApiWhenInstalled() throws Exception {
+            EssentialsTestHelper.setField(service, "manager", scoreboardManager);
+            PluginManager pluginManager = EssentialsTestHelper.getMockServer().getPluginManager();
+            when(pluginManager.getPlugin("PlaceholderAPI")).thenReturn(mock(Plugin.class));
+            config.setScoreboardTitle("%player_name%'s board");
+            config.setScoreboardLines(Collections.emptyList());
+
+            Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+            try (MockedStatic<PlaceholderAPI> papi = mockStatic(PlaceholderAPI.class)) {
+                papi.when(() -> PlaceholderAPI.setPlaceholders(eq(player), anyString()))
+                        .thenReturn("PAPI-RESOLVED");
+
+                service.enableScoreboard(player);
+
+                papi.verify(() -> PlaceholderAPI.setPlaceholders(eq(player), anyString()));
+                verify(mockScoreboard).registerNewObjective(eq("ultiessentials"), eq("dummy"), eq("PAPI-RESOLVED"));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("reload")
+    class ReloadTests {
+
+        @Test
+        @DisplayName("autoEnable=true re-enables the scoreboard for every currently online player")
+        void autoEnableTrueReEnablesOnlinePlayers() throws Exception {
+            EssentialsTestHelper.setField(service, "manager", scoreboardManager);
+            EssentialsTestHelper.setField(service, "bukkitPlugin", mock(Plugin.class));
+            Player online = EssentialsTestHelper.createMockPlayer("Alice", UUID.randomUUID());
+            doReturn(Collections.singletonList(online))
+                    .when(EssentialsTestHelper.getMockServer()).getOnlinePlayers();
+            config.setScoreboardEnabled(true);
+            config.setScoreboardAutoEnable(true);
+
+            service.reload();
+
+            assertThat(service.isEnabled(online)).isTrue();
+        }
+
+        @Test
+        @DisplayName("autoEnable=false leaves online players without a scoreboard after reload")
+        void autoEnableFalseLeavesOnlinePlayersDisabled() throws Exception {
+            EssentialsTestHelper.setField(service, "manager", scoreboardManager);
+            EssentialsTestHelper.setField(service, "bukkitPlugin", mock(Plugin.class));
+            Player online = EssentialsTestHelper.createMockPlayer("Alice", UUID.randomUUID());
+            doReturn(Collections.singletonList(online))
+                    .when(EssentialsTestHelper.getMockServer()).getOnlinePlayers();
+            config.setScoreboardEnabled(true);
+            config.setScoreboardAutoEnable(false);
+
+            service.reload();
+
+            assertThat(service.isEnabled(online)).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/TeleportServiceCountdownTaskTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/TeleportServiceCountdownTaskTest.java
@@ -1,0 +1,174 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.enums.TeleportResult;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link TeleportService}'s warmup-countdown callback -- the anonymous
+ * {@code BukkitRunnable} {@code startWarmupTeleport} schedules via {@code runTaskTimer}. The
+ * existing {@code TeleportServiceMockitoTest} stubs {@code runTaskTimer} to return a mock task
+ * WITHOUT ever invoking the scheduled callback, so this callback's body -- the movement-detection
+ * cancel, the countdown-reaches-zero teleport, and the success/cancel callback dispatch -- has
+ * never run under test. This class captures the scheduled runnable and invokes it directly
+ * (the UltiMail {@code MailServiceTest} idiom for scheduler callbacks) to exercise it.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("TeleportService warmup-countdown callback Tests")
+class TeleportServiceCountdownTaskTest {
+
+    private TeleportService teleportService;
+    private BukkitScheduler scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        Plugin mockBukkitPlugin = mock(Plugin.class);
+
+        scheduler = EssentialsTestHelper.getMockServer().getScheduler();
+        BukkitTask mockTask = mock(BukkitTask.class);
+        lenient().when(scheduler.runTaskTimer(any(Plugin.class), any(Runnable.class), anyLong(), anyLong()))
+                .thenReturn(mockTask);
+
+        teleportService = new TeleportService();
+        EssentialsTestHelper.setField(teleportService, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(teleportService, "bukkitPlugin", mockBukkitPlugin);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private Runnable captureScheduledCallback() {
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).runTaskTimer(any(Plugin.class), captor.capture(), anyLong(), anyLong());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("The countdown reaches zero after its ticks elapse, teleporting the player and invoking onSuccess")
+    void countdownReachingZeroTeleportsAndInvokesOnSuccess() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.getLocation()).thenReturn(new Location(world, 0, 64, 0));
+        when(player.isOnline()).thenReturn(true);
+        Location target = new Location(world, 10, 64, 10);
+        AtomicBoolean successCalled = new AtomicBoolean(false);
+
+        // warmupSeconds=1 schedules the countdown task (0 or below teleports instantly without
+        // ever scheduling anything, so 1 is the minimum that reaches this callback at all).
+        teleportService.teleport(player, target, 1, false, p -> successCalled.set(true), null);
+        Runnable callback = captureScheduledCallback();
+
+        callback.run(); // countdown=1 -> not yet zero: sends the warmup message, decrements
+        verify(player, never()).teleport(any(Location.class));
+        assertThat(successCalled).isFalse();
+
+        callback.run(); // countdown=0 -> teleports and fires onSuccess
+        verify(player).teleport(target);
+        assertThat(successCalled).isTrue();
+        assertThat(teleportService.isTeleporting(player.getUniqueId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("A player who moved beyond the threshold with cancelOnMove has the teleport cancelled and onCancel invoked")
+    void movingTooFarCancelsWarmupAndInvokesOnCancel() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        Location start = new Location(world, 0, 64, 0);
+        when(player.getLocation()).thenReturn(start);
+        when(player.isOnline()).thenReturn(true);
+        Location target = new Location(world, 10, 64, 10);
+        AtomicBoolean cancelCalled = new AtomicBoolean(false);
+
+        teleportService.teleport(player, target, 5, true, null, p -> cancelCalled.set(true));
+        Runnable callback = captureScheduledCallback();
+
+        // Player moves far away before the next tick
+        when(player.getLocation()).thenReturn(new Location(world, 100, 64, 100));
+        callback.run();
+
+        verify(player, never()).teleport(any(Location.class));
+        assertThat(cancelCalled).isTrue();
+        assertThat(teleportService.isTeleporting(player.getUniqueId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("A player who stayed within the threshold with cancelOnMove is not cancelled and the countdown continues")
+    void stayingWithinThresholdDoesNotCancel() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        Location start = new Location(world, 0, 64, 0);
+        when(player.getLocation()).thenReturn(start);
+        when(player.isOnline()).thenReturn(true);
+        Location target = new Location(world, 10, 64, 10);
+
+        teleportService.teleport(player, target, 5, true, null, null);
+        Runnable callback = captureScheduledCallback();
+
+        // Player barely moved (well within the 1-block-squared threshold)
+        when(player.getLocation()).thenReturn(new Location(world, 0.2, 64, 0));
+        callback.run();
+
+        verify(player, never()).teleport(any(Location.class));
+        assertThat(teleportService.isTeleporting(player.getUniqueId())).isTrue();
+        verify(player).sendMessage(anyString());
+    }
+
+    @Test
+    @DisplayName("cancelOnMove=false never checks movement, even for a player who moved far away")
+    void cancelOnMoveFalseIgnoresMovement() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.getLocation()).thenReturn(new Location(world, 0, 64, 0));
+        when(player.isOnline()).thenReturn(true);
+        Location target = new Location(world, 10, 64, 10);
+        AtomicBoolean cancelCalled = new AtomicBoolean(false);
+
+        teleportService.teleport(player, target, 5, false, null, p -> cancelCalled.set(true));
+        Runnable callback = captureScheduledCallback();
+
+        when(player.getLocation()).thenReturn(new Location(world, 100, 64, 100));
+        callback.run();
+
+        assertThat(cancelCalled).isFalse();
+        assertThat(teleportService.isTeleporting(player.getUniqueId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("A player who went offline mid-warmup has the pending teleport cleaned up without teleporting")
+    void offlinePlayerCleansUpWithoutTeleporting() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.getLocation()).thenReturn(new Location(world, 0, 64, 0));
+        when(player.isOnline()).thenReturn(true);
+        Location target = new Location(world, 10, 64, 10);
+
+        teleportService.teleport(player, target, 5, false, null, null);
+        Runnable callback = captureScheduledCallback();
+
+        when(player.isOnline()).thenReturn(false);
+        callback.run();
+
+        verify(player, never()).teleport(any(Location.class));
+        assertThat(teleportService.isTeleporting(player.getUniqueId())).isFalse();
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/TpaServiceTimeoutTaskTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/TpaServiceTimeoutTaskTest.java
@@ -1,0 +1,122 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link TpaService}'s timeout-expiration callback -- the anonymous {@code BukkitRunnable}
+ * {@code startTimeoutTask} schedules via {@code runTaskLater}. The existing
+ * {@code TpaServiceMockitoTest} stubs {@code runTaskLater} to return a mock task WITHOUT ever
+ * invoking the scheduled {@code Runnable}, so this callback's body has never run under test. This
+ * class captures the scheduled runnable and invokes it directly (the {@code MailServiceTest}
+ * idiom from UltiMail, the worked example this ecosystem's scheduler-callback convention points
+ * to), which is what lets both directions of the callback's still-pending-request check -- the
+ * plan's one classified-behavioural decision here -- actually run.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("TpaService timeout-task callback Tests")
+class TpaServiceTimeoutTaskTest {
+
+    private TpaService tpaService;
+    private EssentialsConfig config;
+    private BukkitScheduler scheduler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        config = new EssentialsConfig();
+        Plugin mockBukkitPlugin = mock(Plugin.class);
+
+        scheduler = EssentialsTestHelper.getMockServer().getScheduler();
+        BukkitTask mockTask = mock(BukkitTask.class);
+        lenient().when(scheduler.runTaskLater(any(Plugin.class), any(Runnable.class), anyLong()))
+                .thenReturn(mockTask);
+
+        tpaService = new TpaService();
+        EssentialsTestHelper.setField(tpaService, "config", config);
+        EssentialsTestHelper.setField(tpaService, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(tpaService, "bukkitPlugin", mockBukkitPlugin);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private Player createPlayerInWorld(String name, UUID uuid, World world) {
+        Player player = EssentialsTestHelper.createMockPlayer(name, uuid);
+        lenient().when(player.getWorld()).thenReturn(world);
+        lenient().when(player.isOnline()).thenReturn(true);
+        return player;
+    }
+
+    private Runnable captureScheduledCallback() {
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).runTaskLater(any(Plugin.class), captor.capture(), anyLong());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("A still-pending request is auto-cancelled and both players are notified on timeout")
+    void stillPendingRequestIsCancelledAndBothNotified() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        UUID senderUuid = UUID.randomUUID();
+        UUID targetUuid = UUID.randomUUID();
+        Player sender = createPlayerInWorld("Sender", senderUuid, world);
+        Player target = createPlayerInWorld("Target", targetUuid, world);
+        when(Bukkit.getPlayer(senderUuid)).thenReturn(sender);
+        when(Bukkit.getPlayer(targetUuid)).thenReturn(target);
+
+        tpaService.sendTpaRequest(sender, target);
+        Runnable callback = captureScheduledCallback();
+
+        // The request is still active -- nothing accepted/denied it -- so this pins the
+        // "request != null" branch's true direction.
+        callback.run();
+
+        verify(sender).sendMessage(anyString());
+        verify(target).sendMessage(anyString());
+        assertThat(tpaService.getRequest(targetUuid)).isNull();
+    }
+
+    @Test
+    @DisplayName("A request already resolved before the timeout fires produces no notification")
+    void alreadyResolvedRequestProducesNoNotification() {
+        World world = EssentialsTestHelper.createMockWorld("world");
+        UUID senderUuid = UUID.randomUUID();
+        UUID targetUuid = UUID.randomUUID();
+        Player sender = createPlayerInWorld("Sender", senderUuid, world);
+        Player target = createPlayerInWorld("Target", targetUuid, world);
+        when(Bukkit.getPlayer(senderUuid)).thenReturn(sender);
+        when(Bukkit.getPlayer(targetUuid)).thenReturn(target);
+
+        tpaService.sendTpaRequest(sender, target);
+        Runnable callback = captureScheduledCallback();
+
+        // Resolve the request (e.g. the target accepted/denied it) BEFORE the timeout callback
+        // ever runs -- pinning the "request == null" branch's false-outcome direction.
+        tpaService.cancelRequest(targetUuid);
+
+        callback.run();
+
+        verify(sender, never()).sendMessage(anyString());
+        verify(target, never()).sendMessage(anyString());
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/service/WarpServiceTeleportBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/WarpServiceTeleportBehaviorTest.java
@@ -1,0 +1,130 @@
+package com.ultikits.plugins.essentials.service;
+
+import com.ultikits.plugins.essentials.config.EssentialsConfig;
+import com.ultikits.plugins.essentials.entity.WarpData;
+import com.ultikits.plugins.essentials.enums.TeleportResult;
+import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import com.ultikits.ultitools.interfaces.DataOperator;
+import com.ultikits.ultitools.interfaces.Query;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the {@code teleportToWarp} directions {@code WarpServiceMockitoTest} never reaches: an
+ * accessible warp (no permission node) whose world is no longer registered, and a fully-resolved
+ * warp -- the only place the warmup-skip permission decision is exercised.
+ *
+ * @author wisdomme
+ * @version 1.0.0
+ */
+@DisplayName("WarpService teleportToWarp world-resolution Tests")
+class WarpServiceTeleportBehaviorTest {
+
+    private WarpService warpService;
+    private EssentialsConfig config;
+    private TeleportService teleportService;
+
+    @SuppressWarnings("unchecked")
+    private final DataOperator<WarpData> warpOperator = mock(DataOperator.class);
+
+    @SuppressWarnings("unchecked")
+    private final Query<WarpData> query = mock(Query.class);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        EssentialsTestHelper.setUp();
+
+        config = new EssentialsConfig();
+        teleportService = mock(TeleportService.class);
+
+        warpService = new WarpService();
+        EssentialsTestHelper.setField(warpService, "config", config);
+        EssentialsTestHelper.setField(warpService, "plugin", EssentialsTestHelper.getMockPlugin());
+        EssentialsTestHelper.setField(warpService, "warpOperator", warpOperator);
+        EssentialsTestHelper.setField(warpService, "teleportService", teleportService);
+
+        reset(warpOperator, query);
+        when(warpOperator.query()).thenReturn(query);
+        when(query.where(anyString())).thenReturn(query);
+        when(query.eq(any())).thenReturn(query);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        EssentialsTestHelper.tearDown();
+    }
+
+    private WarpData openWarpIn(String worldName) {
+        return WarpData.builder()
+                .name("spawn")
+                .world(worldName)
+                .x(1).y(64).z(1)
+                .yaw(0).pitch(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("An accessible warp whose world is no longer registered resolves to WORLD_NOT_FOUND")
+    void unregisteredWorldResolvesToWorldNotFound() {
+        when(query.first()).thenReturn(openWarpIn("deleted_world"));
+        Server server = Bukkit.getServer();
+        when(server.getWorld("deleted_world")).thenReturn(null);
+
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+
+        TeleportResult result = warpService.teleportToWarp(player, "spawn");
+
+        assertThat(result).isEqualTo(TeleportResult.WORLD_NOT_FOUND);
+        verify(teleportService, never()).teleport(any(), any(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("A resolved warp delegates to TeleportService with the configured warmup")
+    void resolvedWarpDelegatesWithFullWarmup() {
+        when(query.first()).thenReturn(openWarpIn("world"));
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Server server = Bukkit.getServer();
+        when(server.getWorld("world")).thenReturn(world);
+        config.setWarpTeleportWarmup(5);
+
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.hasPermission("ultiessentials.warp.nowarmup")).thenReturn(false);
+        when(teleportService.teleport(eq(player), any(Location.class), eq(5), anyBoolean()))
+                .thenReturn(TeleportResult.WARMUP_STARTED);
+
+        TeleportResult result = warpService.teleportToWarp(player, "spawn");
+
+        assertThat(result).isEqualTo(TeleportResult.WARMUP_STARTED);
+        verify(teleportService).teleport(eq(player), any(Location.class), eq(5), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("The no-warmup permission skips the configured warmup entirely")
+    void noWarmupPermissionSkipsConfiguredWarmup() {
+        when(query.first()).thenReturn(openWarpIn("world"));
+        World world = EssentialsTestHelper.createMockWorld("world");
+        Server server = Bukkit.getServer();
+        when(server.getWorld("world")).thenReturn(world);
+        config.setWarpTeleportWarmup(5);
+
+        Player player = EssentialsTestHelper.createMockPlayer("Steve", UUID.randomUUID());
+        when(player.hasPermission("ultiessentials.warp.nowarmup")).thenReturn(true);
+        when(teleportService.teleport(eq(player), any(Location.class), eq(0), anyBoolean()))
+                .thenReturn(TeleportResult.SUCCESS);
+
+        TeleportResult result = warpService.teleportToWarp(player, "spawn");
+
+        assertThat(result).isEqualTo(TeleportResult.SUCCESS);
+        verify(teleportService).teleport(eq(player), any(Location.class), eq(0), anyBoolean());
+    }
+}


### PR DESCRIPTION
## Summary

Converts UltiEssentials -- the largest module in the ecosystem (72 main classes, 65 test classes)
-- through the phase-9 module-ecosystem pipeline: pins `UltiTools-API` to the 6.3.0 lineage,
resolves the Central Portal snapshot repository, and adds a live jacoco coverage gate (line >= 0.90,
branch >= 0.80) bound to `verify`.

**The coverage gate is intentionally red on this PR** -- 87.4% line / 70.7% branch. Closing the
105-branch deficit is tracked as separate follow-up work with a ranked, per-class work list; this PR
establishes the gate as live and measured, not silently satisfied.

## What changed

- `pom.xml`: `ultitools.version` retargeted to `6.3.0-SNAPSHOT` (property form); added the
  `central-snapshots` repository; added a jacoco `check` execution (BUNDLE rule) with the GUI
  exclude placed in `CheckMojo`'s own execution-scoped `<excludes>` (a `<rule><excludes>` placement
  is a structural no-op for a BUNDLE-element rule). This module has no `gui` package -- confirmed,
  not assumed: `report` and `check` both analyze the identical 90 classes.
- `.github/workflows/maven-ci.yml`: self-hosted (`mvn -B verify`, JDK 17/21 matrix), replacing the
  shared `ci-workflows@v1` call, which never ran `verify` and so never would have executed the gate.
- `.github/workflows/publish.yml`: removed the dead "Install parent POM" step (no root pom in this
  ecosystem declares a `<parent>`; the step shallow-cloned an archived repository and installed
  nothing anything inherits).
- `.github/dependabot.yml`: new, `github-actions` ecosystem only.
- `.gitignore`: added the two untracked tooling-artifact entries (`.factorypath`, `PROJECT.md`) that
  left every checkout in this milestone's working copy dirty.

Module `<version>` is unchanged -- `publish.yml` triggers a release on push to `master`, and this
module is not being released in this PR.

## Legacy test harness

This module carries `com.github.seeseemelk:MockBukkit-v1.19:3.1.0` (16 of its 65 test classes) plus
Mockito-only tests (49 classes). Measured against a pre-bump baseline taken before any edit and
again after: **814 tests, 0 failures, 0 errors, 52 pre-existing `@Disabled` skips, byte-identical
per-class outcome before and after the framework bump.** The legacy harness works unchanged against
the 6.3.0-compiled module.

## Not in scope for this PR

- Closing the coverage gap (tracked separately, ranked and classified by branch type).
- Any release, tag, or version bump.
- Merging -- opened for review only.
