### PR TITLE
feat: migrate to paper-api 1.21.11 and fix Attribute.GENERIC_MAX_HEALTH rename

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: ['17', '21']
+        java-version: ['21']
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4 (v4.8.0)
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,10 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ultitools.version>6.3.0-SNAPSHOT</ultitools.version>
+        <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
     </properties>
 
     <repositories>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
         <repository>
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
@@ -59,11 +56,19 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Spigot API -->
+        <!-- Paper API -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- XSeries: cross-version Bukkit constant wrappers -->
+        <dependency>
+            <groupId>com.github.cryptomorin</groupId>
+            <artifactId>XSeries</artifactId>
+            <version>13.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/ultikits/plugins/essentials/commands/HealCommand.java
+++ b/src/main/java/com/ultikits/plugins/essentials/commands/HealCommand.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.commands;
 
+import com.cryptomorin.xseries.XAttribute;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.ultitools.annotations.command.*;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -26,7 +26,7 @@ public class HealCommand extends BaseEssentialsCommand {
             return;
         }
 
-        double maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        double maxHealth = player.getAttribute(XAttribute.MAX_HEALTH.get()).getValue();
         player.setHealth(maxHealth);
         player.sendMessage(i18n("生命值已恢复"));
     }
@@ -46,7 +46,7 @@ public class HealCommand extends BaseEssentialsCommand {
             return;
         }
 
-        double maxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        double maxHealth = target.getAttribute(XAttribute.MAX_HEALTH.get()).getValue();
         target.setHealth(maxHealth);
         sender.sendMessage(String.format(i18n("已恢复 %s 的生命值"), target.getName()));
         target.sendMessage(i18n("你的生命值已被恢复"));

--- a/src/test/java/com/ultikits/plugins/essentials/commands/HealCommandTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/HealCommandTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.commands;
 
+import com.cryptomorin.xseries.XAttribute;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.*;
@@ -33,11 +33,11 @@ class HealCommandTest {
         // Mock Attribute for health
         AttributeInstance attrSender = mock(AttributeInstance.class);
         when(attrSender.getValue()).thenReturn(20.0);
-        lenient().when(player.getAttribute(Attribute.GENERIC_MAX_HEALTH)).thenReturn(attrSender);
+        lenient().when(player.getAttribute(XAttribute.MAX_HEALTH.get())).thenReturn(attrSender);
 
         AttributeInstance attrTarget = mock(AttributeInstance.class);
         when(attrTarget.getValue()).thenReturn(20.0);
-        lenient().when(target.getAttribute(Attribute.GENERIC_MAX_HEALTH)).thenReturn(attrTarget);
+        lenient().when(target.getAttribute(XAttribute.MAX_HEALTH.get())).thenReturn(attrTarget);
     }
 
     @AfterEach

--- a/src/test/java/com/ultikits/plugins/essentials/listener/DeathPunishListenerBehaviorTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/DeathPunishListenerBehaviorTest.java
@@ -3,6 +3,7 @@ package com.ultikits.plugins.essentials.listener;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
 import org.bukkit.entity.Player;
+import org.bukkit.damage.DamageSource;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.*;
@@ -32,6 +33,7 @@ class DeathPunishListenerBehaviorTest {
 
     private DeathPunishListener listener;
     private EssentialsConfig config;
+    private DamageSource damageSource;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -40,6 +42,10 @@ class DeathPunishListenerBehaviorTest {
         listener = new DeathPunishListener();
         config = new EssentialsConfig();
         EssentialsTestHelper.setField(listener, "config", config);
+
+        // Paper 1.21's PlayerDeathEvent constructors all require a DamageSource; a mock is enough
+        // here since none of these tests assert on the death cause itself.
+        damageSource = mock(DamageSource.class);
 
         config.setDeathPunishEnabled(true);
         config.setDeathPunishWorldWhitelist(Collections.emptyList());
@@ -82,7 +88,7 @@ class DeathPunishListenerBehaviorTest {
 
             Player player = createDeathPlayer();
             List<ItemStack> drops = new ArrayList<>(Collections.singletonList(mockItem(org.bukkit.Material.DIAMOND)));
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "died");
 
             listener.onPlayerDeath(event);
 
@@ -99,7 +105,7 @@ class DeathPunishListenerBehaviorTest {
 
             Player player = createDeathPlayer();
             List<ItemStack> drops = new ArrayList<>(Collections.singletonList(mockItem(org.bukkit.Material.STONE)));
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "died");
 
             listener.onPlayerDeath(event);
 
@@ -115,7 +121,7 @@ class DeathPunishListenerBehaviorTest {
 
             Player player = createDeathPlayer();
             List<ItemStack> drops = new ArrayList<>(Collections.singletonList(mockItem(org.bukkit.Material.STONE)));
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "died");
 
             listener.onPlayerDeath(event);
 
@@ -137,7 +143,7 @@ class DeathPunishListenerBehaviorTest {
             Player player = createDeathPlayer();
             ItemStack notSelected = mockItem(org.bukkit.Material.STONE);
             List<ItemStack> drops = new ArrayList<>(Collections.singletonList(notSelected));
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "died");
 
             listener.onPlayerDeath(event);
 
@@ -155,7 +161,7 @@ class DeathPunishListenerBehaviorTest {
             Player player = createDeathPlayer();
             ItemStack notSelected = mockItem(org.bukkit.Material.STONE);
             List<ItemStack> drops = new ArrayList<>(Collections.singletonList(notSelected));
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "died");
 
             listener.onPlayerDeath(event);
 

--- a/src/test/java/com/ultikits/plugins/essentials/listener/DeathPunishListenerMockitoTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/DeathPunishListenerMockitoTest.java
@@ -4,6 +4,7 @@ import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
 import org.bukkit.World;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
@@ -27,6 +28,7 @@ class DeathPunishListenerMockitoTest {
 
     private DeathPunishListener listener;
     private EssentialsConfig config;
+    private DamageSource damageSource;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -35,6 +37,10 @@ class DeathPunishListenerMockitoTest {
         listener = new DeathPunishListener();
         config = new EssentialsConfig();
         EssentialsTestHelper.setField(listener, "config", config);
+
+        // Paper 1.21's PlayerDeathEvent constructors all require a DamageSource; a mock is enough
+        // here since none of these tests assert on the death cause itself.
+        damageSource = mock(DamageSource.class);
     }
 
     @AfterEach
@@ -62,7 +68,7 @@ class DeathPunishListenerMockitoTest {
 
             Player player = createDeathPlayer("world");
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "Steve died");
 
             listener.onPlayerDeath(event);
 
@@ -77,7 +83,7 @@ class DeathPunishListenerMockitoTest {
 
             Player player = createDeathPlayer("world_creative");
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "Steve died");
 
             listener.onPlayerDeath(event);
 
@@ -93,7 +99,7 @@ class DeathPunishListenerMockitoTest {
             Player player = createDeathPlayer("world");
             when(player.hasPermission("ultiessentials.deathpunish.bypass")).thenReturn(true);
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "Steve died");
 
             listener.onPlayerDeath(event);
 
@@ -120,7 +126,7 @@ class DeathPunishListenerMockitoTest {
             when(player.getTotalExperience()).thenReturn(1000);
 
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 100, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 100, "Steve died");
 
             listener.onPlayerDeath(event);
 
@@ -145,7 +151,7 @@ class DeathPunishListenerMockitoTest {
             when(player.getTotalExperience()).thenReturn(1000);
 
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 50, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 50, "Steve died");
 
             listener.onPlayerDeath(event);
 
@@ -173,7 +179,7 @@ class DeathPunishListenerMockitoTest {
             when(EssentialsTestHelper.getMockServer().getConsoleSender()).thenReturn(consoleSender);
 
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "Steve died");
 
             listener.onPlayerDeath(event);
 
@@ -200,7 +206,7 @@ class DeathPunishListenerMockitoTest {
 
             Player player = createDeathPlayer("world");
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "Steve died");
 
             // Should not throw, just skip money loss
             listener.onPlayerDeath(event);
@@ -223,7 +229,7 @@ class DeathPunishListenerMockitoTest {
 
             Player player = createDeathPlayer("world");
             List<ItemStack> drops = new ArrayList<>();
-            PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 0, "Steve died");
+            PlayerDeathEvent event = new PlayerDeathEvent(player, damageSource, drops, 0, "Steve died");
 
             listener.onPlayerDeath(event);
 


### PR DESCRIPTION
## Summary

Migrates `UltiEssentials` from `org.spigotmc:spigot-api` 1.20.4 to `io.papermc.paper:paper-api`
1.21.11-R0.1-SNAPSHOT, fixes the compiler-visible `Attribute.GENERIC_MAX_HEALTH` rename this
exposes, and adapts test code to an unrelated `PlayerDeathEvent` constructor removal blocking
compilation.

- `pom.xml`: server API dependency swapped onto a new `paper.version` property, `spigot-repo`
  repository block removed (the `papermc` repository was already declared),
  `com.github.cryptomorin:XSeries:13.0.0` added at `provided` scope.
- `HealCommand.healSelf`/`healOther`: `Attribute.GENERIC_MAX_HEALTH` does not exist at all on Paper
  1.21 -- unlike `Sound.valueOf`, this is a compiler-visible break with no compatibility alias
  (`XAttribute` exposes only the new `MAX_HEALTH` name). Both call sites, and both matching Mockito
  stub sites in `HealCommandTest`, now route through `XAttribute.MAX_HEALTH.get()`. Falsified by
  removal in both directions: reverting either site reproduces
  `cannot find symbol: variable GENERIC_MAX_HEALTH`; restoring passes clean.
- **Unrelated compile-time break, fixed under Rule 3 (blocking issue), not one of the four named
  migration defects:** `PlayerDeathEvent`'s 4-arg constructor `(Player, List<ItemStack>, int,
  String)`, used at 13 call sites across `DeathPunishListenerMockitoTest` (8) and
  `DeathPunishListenerBehaviorTest` (5), no longer exists on `paper-api` 1.21.11 -- every remaining
  overload requires a leading `DamageSource` parameter (confirmed by decompiling the shipped jar).
  Added a Mockito-mocked `DamageSource` (an interface; no live registry needed) as the new second
  argument at each site. Both test classes pass cleanly after the fix.
- CI (`maven-ci.yml`) and publish (`publish.yml`) JDK toolchains bumped to 21 -- `paper-api` 1.21.11
  ships bytecode version 65 (Java 21), unreadable by the previous JDK 17 legs.

## Test results

`mvn -B -o test`: **896 tests run, 0 failures, 11 errors, 52 skipped.**

The 52 skipped are pre-existing and unrelated -- confirmed against a fresh clone of `origin/master`
(pre-migration): identical 896/0/0/52. The migration's own delta is exactly 0 -> 11 errors.

**This is one of only two repositories in the whole 16-module migration that bootstraps any live
test-time Bukkit server at all** (legacy `com.github.seeseemelk:MockBukkit-v1.19:3.1.0`), and it
does not uniformly fail against Paper 1.21 -- three distinct, evidenced behaviours:

1. **Fully resolves:** `HealCommandTest` (the test this PR's own fix touches) passes clean, 6/6, 0
   errors -- `MockBukkit-v1.19`'s `Bukkit.setServer(...)` is sufficient for the `Attribute` registry
   to resolve.
2. **Still fails, literal `RegistryAccess`:** `WildCommandTest`/`WildCommandSafetyCheckTest` (7
   tests) fail via `Material.isSolid()`'s lazily memoized registry-backed lookup -- the same
   `IllegalStateException: No RegistryAccess implementation found` seen everywhere else in this
   migration.
3. **Silently produces a different code path (new shape, not seen elsewhere in this migration):**
   `BanListenerMockitoTest$OnPlayerLoginTests` (4 tests) fail with a `NullPointerException` on a null
   `PlayerProfile`, because `Bukkit.createProfile(...)` -- called internally by the deprecated
   `AsyncPlayerPreLoginEvent` constructor these tests use -- returns `null` on MockBukkit-v1.19's mock
   `Server` rather than throwing. Full reasoning and recommendation to Phase 14 recorded in this
   milestone's local evidence tree (plan 12-05's handoff-ledger fragment).

0 of the 11 are either fixed defect (`Attribute.GENERIC_MAX_HEALTH`) surviving; 0 unexplained.

`mvn -B -o clean test-compile`: exit 0.

**Deliberate break, both directions:**
```
$ mvn -B -o clean test-compile   # Attribute.GENERIC_MAX_HEALTH reverted
[ERROR] .../HealCommand.java:[30,57] cannot find symbol
  symbol:   variable GENERIC_MAX_HEALTH
$ echo $?
1
$ mvn -B -o clean test-compile   # XAttribute.MAX_HEALTH.get() restored
[INFO] BUILD SUCCESS
$ echo $?
0
```

## Issue closure

Closes #16

This repository has other open defect issues -- they are Phase 13's, not this migration's, and are
left untouched.

## Notes for reviewers

- This is one of the sixteen Phase 12 migration pull requests. A red CI here is expected and covered
  by a narrow, time-boxed CI waiver recorded in this milestone's local evidence tree (all four
  conditions hold: root cause is the registry/environment gap via two evidenced shapes plus one novel
  shape recorded distinctly, every failure enumerated, zero named defects survive, zero unexplained).
- Whether `MockBukkit-v1.19:3.1.0` remains viable on Paper 1.21 is explicitly **not** answered or
  fixed by this pull request -- that's Phase 14's own verification obligation, and the three-shape
  finding above is handed to it as evidence, not resolved here.
- Codacy not run -- repository not onboarded to Codacy. Third-party review for this pull request is
  the Codex/ChatGPT review alone.
- Nothing is merged by this pull request being opened; merge follows plan 12-11's gate check.
