### PR TITLE
test: bootstrap a live test-time server and migrate off legacy MockBukkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- MockBukkit (Paper 1.21 generation) for Bukkit API mocking -->
+        <dependency>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1.21</artifactId>
+            <version>4.101.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Mockito for mocking -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <id>sonatype-releases</id>
             <url>https://s01.oss.sonatype.org/content/repositories/releases/</url>
         </repository>
-        <!-- JitPack for MockBukkit -->
+        <!-- JitPack for XSeries -->
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
@@ -104,19 +104,11 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- MockBukkit (Paper 1.21 generation) for Bukkit API mocking -->
+        <!-- MockBukkit for Bukkit API mocking -->
         <dependency>
             <groupId>org.mockbukkit.mockbukkit</groupId>
             <artifactId>mockbukkit-v1.21</artifactId>
             <version>4.101.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- MockBukkit for Bukkit API mocking -->
-        <dependency>
-            <groupId>com.github.seeseemelk</groupId>
-            <artifactId>MockBukkit-v1.19</artifactId>
-            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,19 +104,19 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- MockBukkit for Bukkit API mocking -->
-        <dependency>
-            <groupId>com.github.seeseemelk</groupId>
-            <artifactId>MockBukkit-v1.19</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
-        </dependency>
-
         <!-- MockBukkit (Paper 1.21 generation) for Bukkit API mocking -->
         <dependency>
             <groupId>org.mockbukkit.mockbukkit</groupId>
             <artifactId>mockbukkit-v1.21</artifactId>
             <version>4.101.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- MockBukkit for Bukkit API mocking -->
+        <dependency>
+            <groupId>com.github.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.19</artifactId>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
@@ -7,11 +7,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockbukkit.mockbukkit.ServerMock;
+
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -54,9 +58,22 @@ public class UltiEssentialsRegistrySentinelTest {
         MockBukkitHelper.safeUnmock();
     }
 
+    /**
+     * Asserts the installed server's <em>type</em>, not merely its presence.
+     *
+     * <p>A bare {@code assertNotNull(Bukkit.getServer())} does not establish that this class's
+     * bootstrap ran: it is equally satisfied by the raw Mockito {@code mock(Server.class)} that
+     * {@code EssentialsTestHelper.setUp()} installs and never clears. Measured with the bootstrap
+     * removed and such a mock installed in its place, this class's other three tests failed while
+     * the {@code assertNotNull} form of this one still passed -- a reopen guard that a leaked mock
+     * can satisfy is not guarding the bootstrap.</p>
+     */
     @Test
     void liveServerIsBootstrapped() {
-        assertNotNull(Bukkit.getServer(), "live server bootstrap must be present");
+        assertInstanceOf(ServerMock.class, Bukkit.getServer(),
+            "live server bootstrap must install a MockBukkit ServerMock; a raw Mockito "
+                + "mock(Server.class) leaked by another test class satisfies a bare assertNotNull "
+                + "but is not a live server");
     }
 
     @Test
@@ -70,9 +87,36 @@ public class UltiEssentialsRegistrySentinelTest {
         assertNotNull(profile, "createProfile must not silently return null");
     }
 
+    /**
+     * Guards the registry path, and names the failure it produces.
+     *
+     * <p>Without the bootstrap, {@code new ItemStack(...)} throws MockBukkit's
+     * {@code IncompatiblePaperVersionException}, whose text reads "Version Mismatch!" and advises
+     * recompiling against a matching Paper API. <b>That advice is a dead end here.</b> The versions
+     * already match: MockBukkit 4.101.0 reports itself built against Paper API
+     * 1.21.11-R0.1-SNAPSHOT, and that is exactly what {@code pom.xml} depends on.
+     * {@code RegistryMock.loadIfEmpty} catches {@code ExceptionInInitializerError} and reports
+     * every instance as a version mismatch, so the message describes the catch site rather than the
+     * cause. Both absent-bootstrap shapes were measured, and both bottom out in
+     * {@code Tag.<clinit>} calling {@code Bukkit.getTag(...)} without a live server behind it:
+     * a {@code NullPointerException} on a null {@code Bukkit.server}, or the same on a raw Mockito
+     * {@code mock(Server.class)} returning null from the unstubbed call. Neither is a Paper version
+     * problem.</p>
+     *
+     * <p>The assertion message below carries that so the next maintainer reads it at the point of
+     * failure instead of rediscovering it.</p>
+     */
     @Test
     void itemStackConstructionResolvesRegistry() {
-        ItemStack stack = new ItemStack(Material.DIAMOND);
+        ItemStack stack = assertDoesNotThrow(
+            () -> new ItemStack(Material.DIAMOND),
+            "ItemStack construction must resolve MockBukkit's registry. If this reports "
+                + "IncompatiblePaperVersionException \"Version Mismatch!\", do NOT go looking for a "
+                + "version to correct -- MockBukkit 4.101.0 and this pom both target Paper "
+                + "1.21.11-R0.1-SNAPSHOT. RegistryMock.loadIfEmpty reports any "
+                + "ExceptionInInitializerError under that message; the real cause is Tag.<clinit> "
+                + "calling Bukkit.getTag(...) without a live server behind it (Bukkit.server null, "
+                + "or a raw Mockito mock returning null), i.e. the live server bootstrap is missing");
         assertNotNull(stack);
         assertEquals(Material.DIAMOND, stack.getType());
     }

--- a/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
@@ -1,0 +1,47 @@
+package com.ultikits.plugins.essentials;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Reopen guard for the live test-time server bootstrap (mockbukkit-v1.21).
+ *
+ * <p>Every assertion here depends on a live server, never a bare registry constant --
+ * mockbukkit-v1.21 registers its {@code RegistryAccess} mock via {@code ServiceLoader}, so a
+ * registry constant alone would resolve merely from the dependency being on the classpath, even
+ * with every {@code MockBukkit.mock()} call deleted. This class must go red the moment the
+ * bootstrap is removed, and green the moment it is restored.</p>
+ */
+public class UltiEssentialsRegistrySentinelTest {
+
+    @Test
+    void liveServerIsBootstrapped() {
+        assertNotNull(Bukkit.getServer(), "live server bootstrap must be present");
+    }
+
+    @Test
+    void unsafeValuesResolves() {
+        assertNotNull(Bukkit.getUnsafe(), "UnsafeValues must resolve on a live server");
+    }
+
+    @Test
+    void createProfileDoesNotSilentlyReturnNull() {
+        Object profile = Bukkit.createProfile(UUID.randomUUID(), "SentinelPlayer");
+        assertNotNull(profile, "createProfile must not silently return null");
+    }
+
+    @Test
+    void itemStackConstructionResolvesRegistry() {
+        ItemStack stack = new ItemStack(Material.DIAMOND);
+        assertNotNull(stack);
+        assertEquals(Material.DIAMOND, stack.getType());
+    }
+}

--- a/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 
+import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
+
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,11 +23,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * registry constant alone would resolve merely from the dependency being on the classpath, even
  * with every {@code MockBukkit.mock()} call deleted. This class must go red the moment the
  * bootstrap is removed, and green the moment it is restored.</p>
+ *
+ * <p>{@link MockBukkitHelper#clearForeignServer()} guards against a real, measured hazard in this
+ * repository: several test classes (e.g. {@code WildCommandTest} via {@code EssentialsTestHelper})
+ * install a raw Mockito {@code mock(Server.class)} into {@code Bukkit.server} via reflection and
+ * never clear it. Without this call, this sentinel's own {@code MockBukkit.mock()} throws
+ * {@code UnsupportedOperationException: Cannot redefine singleton Server} whenever it happens to
+ * run after one of those classes in the same forked JVM -- a reopen guard must not itself be
+ * fragile to unrelated test ordering (14-09).</p>
  */
 public class UltiEssentialsRegistrySentinelTest {
 
     @BeforeEach
     void setUp() {
+        MockBukkitHelper.clearForeignServer();
         MockBukkit.mock();
     }
 

--- a/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
@@ -6,7 +6,6 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockbukkit.mockbukkit.MockBukkit;
 
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 
@@ -16,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * Reopen guard for the live test-time server bootstrap (mockbukkit-v1.21).
+ * Reopen guard for the module's shared test-time server bootstrap (mockbukkit-v1.21).
  *
  * <p>Every assertion here depends on a live server, never a bare registry constant --
  * mockbukkit-v1.21 registers its {@code RegistryAccess} mock via {@code ServiceLoader}, so a
@@ -24,25 +23,35 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * with every {@code MockBukkit.mock()} call deleted. This class must go red the moment the
  * bootstrap is removed, and green the moment it is restored.</p>
  *
- * <p>{@link MockBukkitHelper#clearForeignServer()} guards against a real, measured hazard in this
- * repository: several test classes (e.g. {@code WildCommandTest} via {@code EssentialsTestHelper})
- * install a raw Mockito {@code mock(Server.class)} into {@code Bukkit.server} via reflection and
- * never clear it. Without this call, this sentinel's own {@code MockBukkit.mock()} throws
- * {@code UnsupportedOperationException: Cannot redefine singleton Server} whenever it happens to
- * run after one of those classes in the same forked JVM -- a reopen guard must not itself be
- * fragile to unrelated test ordering (14-09).</p>
+ * <p><b>Bootstraps through {@link MockBukkitHelper#bootstrapLiveServer()}, deliberately not its
+ * own {@code MockBukkit.mock()} call.</b> An earlier revision of this class called
+ * {@code MockBukkit.mock()} directly, which meant this sentinel only proved that MockBukkit's own
+ * API resolves a live server -- it did not notice a regression in the module's shared bootstrap at
+ * all, because it never depended on it. {@code MockBukkitHelper.bootstrapLiveServer()} is this
+ * module's one shared entry point: it is also the exact sequence {@code BanListenerMockitoTest}
+ * (a real production-path test, not a sentinel) depends on to make
+ * {@code Bukkit.createProfile(...)} resolve for {@code BanListener.onPlayerLogin}. Breaking or
+ * removing {@code bootstrapLiveServer()} now fails both classes, not just this one (14-13).</p>
+ *
+ * <p>{@code bootstrapLiveServer()} itself opens with {@link MockBukkitHelper#clearForeignServer()},
+ * which guards against a real, measured hazard in this repository: several test classes (e.g.
+ * {@code WildCommandTest} via {@code EssentialsTestHelper}) install a raw Mockito
+ * {@code mock(Server.class)} into {@code Bukkit.server} via reflection and never clear it. Without
+ * that pre-step, {@code MockBukkit.mock()} throws {@code UnsupportedOperationException: Cannot
+ * redefine singleton Server} whenever this sentinel happens to run after one of those classes in
+ * the same forked JVM -- a reopen guard must not itself be fragile to unrelated test ordering
+ * (14-09). Kept here unchanged; only the call site moved.</p>
  */
 public class UltiEssentialsRegistrySentinelTest {
 
     @BeforeEach
     void setUp() {
-        MockBukkitHelper.clearForeignServer();
-        MockBukkit.mock();
+        MockBukkitHelper.bootstrapLiveServer();
     }
 
     @AfterEach
     void tearDown() {
-        MockBukkit.unmock();
+        MockBukkitHelper.safeUnmock();
     }
 
     @Test

--- a/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsRegistrySentinelTest.java
@@ -3,6 +3,8 @@ package com.ultikits.plugins.essentials;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 
@@ -21,6 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * bootstrap is removed, and green the moment it is restored.</p>
  */
 public class UltiEssentialsRegistrySentinelTest {
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
 
     @Test
     void liveServerIsBootstrapped() {

--- a/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/UltiEssentialsTest.java
@@ -1,7 +1,7 @@
 package com.ultikits.plugins.essentials;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 import com.ultikits.plugins.essentials.utils.TestHelper;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/ultikits/plugins/essentials/commands/BaseEssentialsCommandTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/commands/BaseEssentialsCommandTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.commands;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.enums.TeleportResult;
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 import com.ultikits.ultitools.annotations.*;

--- a/src/test/java/com/ultikits/plugins/essentials/entity/HomeDataTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/entity/HomeDataTest.java
@@ -1,7 +1,7 @@
 package com.ultikits.plugins.essentials.entity;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 import org.bukkit.Location;
 import org.bukkit.World;

--- a/src/test/java/com/ultikits/plugins/essentials/entity/LocationDataEntityTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/entity/LocationDataEntityTest.java
@@ -1,7 +1,7 @@
 package com.ultikits.plugins.essentials.entity;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 import org.bukkit.Location;
 import org.bukkit.World;

--- a/src/test/java/com/ultikits/plugins/essentials/entity/WarpDataTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/entity/WarpDataTest.java
@@ -1,7 +1,7 @@
 package com.ultikits.plugins.essentials.entity;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 import org.bukkit.Location;
 import org.bukkit.World;

--- a/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
@@ -34,26 +34,24 @@ class BanListenerMockitoTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        EssentialsTestHelper.setUp();
-
-        // EssentialsTestHelper.setUp() above just installed its own raw, unstubbed
-        // Mockito Server mock into Bukkit.server via reflection. That mock never
-        // stubs Server.createProfile(...), so AsyncPlayerPreLoginEvent's 3-arg
-        // constructor -- which delegates to Bukkit.createProfile(uuid, name) --
-        // silently gets back null (Mockito's default return for an unstubbed
-        // Object-returning method), and the NPE only surfaces one call later
-        // inside production code (BanListener.onPlayerLogin -> getUniqueId()).
-        // Give this class its own explicit, live-server bootstrap for that one
-        // call, via the module's shared MockBukkitHelper.bootstrapLiveServer():
-        // clears the raw mock (bypassing Bukkit.setServer()'s "already set"
-        // guard the same way EssentialsTestHelper itself does) and installs a
-        // real MockBukkit ServerMock instead, so createProfile() genuinely
-        // resolves rather than depending on either Mockito's default or on
-        // another class's leftover state (14-09, shape 3). Routed through the
-        // shared helper method (not an inlined MockBukkit.mock() call) so this
-        // class's greenness -- a real production-path test of
-        // BanListener.onPlayerLogin -- is exactly what UltiEssentialsRegistrySentinelTest
-        // is now also standing guard over (14-13).
+        // No EssentialsTestHelper.setUp() call here, deliberately. It installs a raw,
+        // unstubbed Mockito mock(Server.class) into Bukkit.server via reflection and never
+        // clears it -- and this class consumed nothing it produced. Every helper member was
+        // checked: only setField (a static reflection helper that needs no fixture) and
+        // tearDown are referenced; getMockPlugin, getMockLogger, getMockServer,
+        // createDefaultConfig and createMockPlayer are all absent, and both
+        // new EssentialsConfig() and mock(BanService.class) below need nothing from it.
+        // Its one observable effect was the foreign server that the next line then had to
+        // clear again, so the call was removed at the root rather than worked around.
+        //
+        // A genuinely live server is still required: AsyncPlayerPreLoginEvent's 3-arg
+        // constructor delegates to Bukkit.createProfile(uuid, name), and an unstubbed
+        // Mockito Server returns null there (Mockito's default for an Object-returning
+        // method), with the NPE surfacing one call later inside production code at
+        // BanListener.onPlayerLogin -> getUniqueId(). Routed through the module's shared
+        // MockBukkitHelper.bootstrapLiveServer() rather than an inlined MockBukkit.mock()
+        // so this class's greenness -- a real production-path test, not a sentinel -- is
+        // exactly what UltiEssentialsRegistrySentinelTest stands guard over (14-13).
         MockBukkitHelper.bootstrapLiveServer();
 
         config = new EssentialsConfig();

--- a/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
@@ -8,7 +8,6 @@ import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.junit.jupiter.api.*;
-import org.mockbukkit.mockbukkit.MockBukkit;
 
 import java.net.InetAddress;
 import java.util.UUID;
@@ -45,13 +44,17 @@ class BanListenerMockitoTest {
         // Object-returning method), and the NPE only surfaces one call later
         // inside production code (BanListener.onPlayerLogin -> getUniqueId()).
         // Give this class its own explicit, live-server bootstrap for that one
-        // call: clear the raw mock (bypassing Bukkit.setServer()'s "already set"
-        // guard the same way EssentialsTestHelper itself does) and install a
+        // call, via the module's shared MockBukkitHelper.bootstrapLiveServer():
+        // clears the raw mock (bypassing Bukkit.setServer()'s "already set"
+        // guard the same way EssentialsTestHelper itself does) and installs a
         // real MockBukkit ServerMock instead, so createProfile() genuinely
         // resolves rather than depending on either Mockito's default or on
-        // another class's leftover state (14-09, shape 3).
-        MockBukkitHelper.clearForeignServer();
-        MockBukkit.mock();
+        // another class's leftover state (14-09, shape 3). Routed through the
+        // shared helper method (not an inlined MockBukkit.mock() call) so this
+        // class's greenness -- a real production-path test of
+        // BanListener.onPlayerLogin -- is exactly what UltiEssentialsRegistrySentinelTest
+        // is now also standing guard over (14-13).
+        MockBukkitHelper.bootstrapLiveServer();
 
         config = new EssentialsConfig();
         banService = mock(BanService.class);

--- a/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
@@ -37,8 +37,8 @@ class BanListenerMockitoTest {
         // No EssentialsTestHelper.setUp() call here, deliberately. It installs a raw,
         // unstubbed Mockito mock(Server.class) into Bukkit.server via reflection and never
         // clears it -- and this class consumed nothing it produced. Every helper member was
-        // checked: only setField (a static reflection helper that needs no fixture) and
-        // tearDown are referenced; getMockPlugin, getMockLogger, getMockServer,
+        // checked: only setField (a static reflection helper that needs no fixture) is
+        // referenced; getMockPlugin, getMockLogger, getMockServer,
         // createDefaultConfig and createMockPlayer are all absent, and both
         // new EssentialsConfig() and mock(BanService.class) below need nothing from it.
         // Its one observable effect was the foreign server that the next line then had to
@@ -63,9 +63,13 @@ class BanListenerMockitoTest {
     }
 
     @AfterEach
-    void tearDown() throws Exception {
+    void tearDown() {
+        // No EssentialsTestHelper.tearDown() call here, deliberately -- it is the pair of a
+        // setUp() this class does not perform. All it does is null the shared statics
+        // mockPlugin and mockLogger, which belong to other classes' fixtures; it never
+        // touches Bukkit.server (its own comment says so). Clearing the server is
+        // safeUnmock()'s job above, and that is the only teardown this class needs.
         MockBukkitHelper.safeUnmock();
-        EssentialsTestHelper.tearDown();
     }
 
     @Nested

--- a/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/listener/BanListenerMockitoTest.java
@@ -4,9 +4,11 @@ import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.entity.BanData;
 import com.ultikits.plugins.essentials.service.BanService;
 import com.ultikits.plugins.essentials.utils.EssentialsTestHelper;
+import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.junit.jupiter.api.*;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 import java.net.InetAddress;
 import java.util.UUID;
@@ -35,6 +37,22 @@ class BanListenerMockitoTest {
     void setUp() throws Exception {
         EssentialsTestHelper.setUp();
 
+        // EssentialsTestHelper.setUp() above just installed its own raw, unstubbed
+        // Mockito Server mock into Bukkit.server via reflection. That mock never
+        // stubs Server.createProfile(...), so AsyncPlayerPreLoginEvent's 3-arg
+        // constructor -- which delegates to Bukkit.createProfile(uuid, name) --
+        // silently gets back null (Mockito's default return for an unstubbed
+        // Object-returning method), and the NPE only surfaces one call later
+        // inside production code (BanListener.onPlayerLogin -> getUniqueId()).
+        // Give this class its own explicit, live-server bootstrap for that one
+        // call: clear the raw mock (bypassing Bukkit.setServer()'s "already set"
+        // guard the same way EssentialsTestHelper itself does) and install a
+        // real MockBukkit ServerMock instead, so createProfile() genuinely
+        // resolves rather than depending on either Mockito's default or on
+        // another class's leftover state (14-09, shape 3).
+        MockBukkitHelper.clearForeignServer();
+        MockBukkit.mock();
+
         config = new EssentialsConfig();
         banService = mock(BanService.class);
 
@@ -45,6 +63,7 @@ class BanListenerMockitoTest {
 
     @AfterEach
     void tearDown() throws Exception {
+        MockBukkitHelper.safeUnmock();
         EssentialsTestHelper.tearDown();
     }
 

--- a/src/test/java/com/ultikits/plugins/essentials/service/BanServiceTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/BanServiceTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.service;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.entity.BanData;
 import com.ultikits.plugins.essentials.service.BanService.BanResult;

--- a/src/test/java/com/ultikits/plugins/essentials/service/ChestLockServiceTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/ChestLockServiceTest.java
@@ -1,9 +1,9 @@
 package com.ultikits.plugins.essentials.service;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.entity.ChestLockData;
 import com.ultikits.plugins.essentials.service.ChestLockService.LockResult;

--- a/src/test/java/com/ultikits/plugins/essentials/service/HomeServiceTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/HomeServiceTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.service;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.UltiEssentials;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.entity.HomeData;

--- a/src/test/java/com/ultikits/plugins/essentials/service/TeleportServiceTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/TeleportServiceTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.service;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.enums.TeleportResult;
 import com.ultikits.plugins.essentials.utils.MockBukkitHelper;
 import com.ultikits.plugins.essentials.utils.TestHelper;

--- a/src/test/java/com/ultikits/plugins/essentials/service/TpaServiceTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/TpaServiceTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.service;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.service.TpaService.TpaResult;
 import com.ultikits.plugins.essentials.service.TpaService.TpaRequest;

--- a/src/test/java/com/ultikits/plugins/essentials/service/WarpServiceTest.java
+++ b/src/test/java/com/ultikits/plugins/essentials/service/WarpServiceTest.java
@@ -1,8 +1,8 @@
 package com.ultikits.plugins.essentials.service;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.ultikits.plugins.essentials.config.EssentialsConfig;
 import com.ultikits.plugins.essentials.entity.WarpData;
 import com.ultikits.plugins.essentials.enums.TeleportResult;

--- a/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
+++ b/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Field;
 import org.bukkit.Bukkit;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 /**
  * MockBukkit 测试工具类
@@ -100,5 +101,30 @@ public final class MockBukkitHelper {
             }
         } catch (Exception ignored) {
         }
+    }
+
+    /**
+     * The module's single, shared entry point for bootstrapping a live MockBukkit server in an
+     * active (non-{@code @Disabled}) test class.
+     *
+     * <p>Before this method existed, {@code UltiEssentialsRegistrySentinelTest} and
+     * {@code BanListenerMockitoTest} -- the only two currently-enabled test classes in this module
+     * that need a genuinely live server rather than a raw Mockito {@code mock(Server.class)} --
+     * each inlined the identical {@link #clearForeignServer()} + {@code MockBukkit.mock()} pair
+     * independently. That duplication defeated the sentinel's own purpose: deleting or breaking
+     * this bootstrap sequence in the sentinel's own {@code @BeforeEach} left every other class's
+     * live-server wiring untouched, so the sentinel could go red while the module's actual
+     * production-path test ({@code BanListenerMockitoTest}, which exercises
+     * {@code BanListener.onPlayerLogin} against a real {@code Bukkit.createProfile(...)}) never
+     * noticed. Routing both classes through this one method means breaking it breaks both --
+     * the sentinel is now watching the same wiring the production-path test actually depends on,
+     * not merely its own private copy of it (14-13).</p>
+     *
+     * @return the freshly-mocked {@link ServerMock}, for callers that need direct access to it
+     *         (e.g. to add players or worlds) without a second lookup via {@link MockBukkit#getMock()}
+     */
+    public static ServerMock bootstrapLiveServer() {
+        clearForeignServer();
+        return MockBukkit.mock();
     }
 }

--- a/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
+++ b/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
@@ -1,6 +1,7 @@
 /**
- * Synced from UltiTools-API v6.2.0 - 2026-01-08
- * Source: src/test/java/com/ultikits/ultitools/utils/MockBukkitHelper.java
+ * Migrated off the legacy `be.seeseemelk.mockbukkit` generation to
+ * `org.mockbukkit.mockbukkit` (Phase 14, 14-09) - 2026-09-06.
+ * Source of the original pattern: src/test/java/com/ultikits/ultitools/utils/MockBukkitHelper.java
  *
  * 如需更新，请从 UltiTools-Reborn 主项目同步此文件
  */
@@ -10,7 +11,7 @@ import java.lang.reflect.Field;
 
 import org.bukkit.Bukkit;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 /**
  * MockBukkit 测试工具类
@@ -41,11 +42,14 @@ public final class MockBukkitHelper {
         } catch (Exception ignored) {
         }
 
-        // Reset the mocked flag so MockBukkit.mock() can be called again
+        // Reset the static mock-holder field so MockBukkit.mock() can be called again.
+        // NOTE (14-09): on the 1.21 generation this field is named `mock`
+        // (a private static ServerMock), not the legacy `mocked` boolean flag --
+        // confirmed via javap, `mocked` does not exist on this generation at all.
         try {
-            Field mockedField = MockBukkit.class.getDeclaredField("mocked");
-            mockedField.setAccessible(true);
-            mockedField.setBoolean(null, false);
+            Field mockField = MockBukkit.class.getDeclaredField("mock");
+            mockField.setAccessible(true);
+            mockField.set(null, null);
         } catch (Exception ignored) {
         }
 
@@ -61,6 +65,39 @@ public final class MockBukkitHelper {
     public static void safeUnmock() {
         try {
             MockBukkit.unmock();
+        } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Clears {@code Bukkit.server} when it is occupied by something MockBukkit
+     * did not install -- most commonly {@code EssentialsTestHelper.setUp()}'s own
+     * raw Mockito {@code mock(Server.class)}, which several test classes in this
+     * repository set via reflection (bypassing {@code Bukkit.setServer()}'s own
+     * "already set" guard) and deliberately never clear afterward.
+     *
+     * <p>Call this immediately before {@code MockBukkit.mock()} in a test class
+     * whose fixture (or a fixture that ran earlier in the same forked JVM) may
+     * have left a non-MockBukkit occupant behind -- {@code MockBukkit.mock()}
+     * itself throws {@code UnsupportedOperationException: Cannot redefine
+     * singleton Server} if {@code Bukkit.server} is already non-null, from any
+     * source (14-09).</p>
+     *
+     * <p><b>Deliberately distinct from {@link #ensureCleanState()}'s own "do not
+     * clear Bukkit.server" rule.</b> That rule protects against double-clearing a
+     * server MockBukkit itself owns, which can leave already-memoized
+     * registry/PotionEffectType static caches pointing at a torn-down instance.
+     * This method only acts when {@link MockBukkit#isMocked()} is already
+     * {@code false} -- i.e. the occupant, if any, was never MockBukkit's to begin
+     * with, so no such cache exists yet to corrupt.</p>
+     */
+    public static void clearForeignServer() {
+        try {
+            if (!MockBukkit.isMocked() && Bukkit.getServer() != null) {
+                Field serverField = Bukkit.class.getDeclaredField("server");
+                serverField.setAccessible(true);
+                serverField.set(null, null);
+            }
         } catch (Exception ignored) {
         }
     }

--- a/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
+++ b/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
@@ -10,6 +10,7 @@ package com.ultikits.plugins.essentials.utils;
 import java.lang.reflect.Field;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
@@ -71,34 +72,55 @@ public final class MockBukkitHelper {
     }
 
     /**
-     * Clears {@code Bukkit.server} when it is occupied by something MockBukkit
-     * did not install -- most commonly {@code EssentialsTestHelper.setUp()}'s own
-     * raw Mockito {@code mock(Server.class)}, which several test classes in this
-     * repository set via reflection (bypassing {@code Bukkit.setServer()}'s own
-     * "already set" guard) and deliberately never clear afterward.
+     * Leaves {@code Bukkit.server} null, so that a following {@code MockBukkit.mock()} can install
+     * its own {@link ServerMock}. {@code MockBukkit.mock(T)} delegates to
+     * {@code Bukkit.setServer(...)}, which throws {@code UnsupportedOperationException: Cannot
+     * redefine singleton Server} whenever that field is already occupied, from any source
+     * (verified against paper-api 1.21.11: {@code Bukkit.setServer} offsets 0-15).
      *
-     * <p>Call this immediately before {@code MockBukkit.mock()} in a test class
-     * whose fixture (or a fixture that ran earlier in the same forked JVM) may
-     * have left a non-MockBukkit occupant behind -- {@code MockBukkit.mock()}
-     * itself throws {@code UnsupportedOperationException: Cannot redefine
-     * singleton Server} if {@code Bukkit.server} is already non-null, from any
-     * source (14-09).</p>
+     * <p>The usual occupant is {@code EssentialsTestHelper.setUp()}'s raw Mockito
+     * {@code mock(Server.class)}, which several test classes in this repository install via
+     * reflection (bypassing {@code Bukkit.setServer()}'s own "already set" guard) and deliberately
+     * never clear afterward. Call this immediately before {@code MockBukkit.mock()} in any class
+     * that may run after one of those in the same forked JVM (14-09).</p>
      *
-     * <p><b>Deliberately distinct from {@link #ensureCleanState()}'s own "do not
-     * clear Bukkit.server" rule.</b> That rule protects against double-clearing a
-     * server MockBukkit itself owns, which can leave already-memoized
-     * registry/PotionEffectType static caches pointing at a torn-down instance.
-     * This method only acts when {@link MockBukkit#isMocked()} is already
-     * {@code false} -- i.e. the occupant, if any, was never MockBukkit's to begin
-     * with, so no such cache exists yet to corrupt.</p>
+     * <p><b>The occupant is classified by its runtime type, not by {@link MockBukkit#isMocked()}.</b>
+     * An earlier revision guarded on {@code !isMocked()} and argued that a false reading proved the
+     * occupant "was never MockBukkit's to begin with, so no memoized registry/PotionEffectType cache
+     * exists yet to corrupt". That inference does not follow. {@code isMocked()} is exactly
+     * {@code mock != null} (MockBukkit 4.101.0 bytecode), and {@link #ensureCleanState()} nulls that
+     * same holder field <em>unconditionally</em> while deliberately not touching
+     * {@code Bukkit.server}. This repository can reach the resulting split state:
+     * {@code ensureCleanState()} swallows every exception, and {@code MockBukkit.unmock()}'s leading
+     * instructions -- offsets 7-22, {@code mock.getPluginManager()} and {@code disablePlugins()} --
+     * sit outside its own exception table, which covers only 25-34, so a throw there escapes before
+     * {@code setServerInstanceToNull()} ever runs. {@code isMocked()} then reads {@code false} while
+     * {@code Bukkit.server} still holds a live {@code ServerMock}, and the old guard would have torn
+     * that server down through the "foreign" path it was written to avoid.</p>
+     *
+     * <p>So a {@link ServerMock} occupant is handed back to MockBukkit via {@link #safeUnmock()}
+     * first, letting MockBukkit's own teardown bookkeeping run, and is cleared reflectively only if
+     * that leaves the field still occupied -- which is what an orphaned {@code ServerMock} (holder
+     * already nulled, so {@code unmock()} returns immediately) looks like, and is the same clear
+     * MockBukkit's own {@code setServerInstanceToNull()} performs. Anything else is genuinely
+     * foreign and is cleared directly. Either way the postcondition is the one callers need:
+     * {@code Bukkit.server == null}.</p>
      */
     public static void clearForeignServer() {
         try {
-            if (!MockBukkit.isMocked() && Bukkit.getServer() != null) {
-                Field serverField = Bukkit.class.getDeclaredField("server");
-                serverField.setAccessible(true);
-                serverField.set(null, null);
+            Server occupant = Bukkit.getServer();
+            if (occupant == null) {
+                return;
             }
+            if (occupant instanceof ServerMock) {
+                safeUnmock();
+                if (Bukkit.getServer() == null) {
+                    return;
+                }
+            }
+            Field serverField = Bukkit.class.getDeclaredField("server");
+            serverField.setAccessible(true);
+            serverField.set(null, null);
         } catch (Exception ignored) {
         }
     }

--- a/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
+++ b/src/test/java/com/ultikits/plugins/essentials/utils/MockBukkitHelper.java
@@ -10,7 +10,6 @@ package com.ultikits.plugins.essentials.utils;
 import java.lang.reflect.Field;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Server;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
@@ -45,15 +44,7 @@ public final class MockBukkitHelper {
         }
 
         // Reset the static mock-holder field so MockBukkit.mock() can be called again.
-        // NOTE (14-09): on the 1.21 generation this field is named `mock`
-        // (a private static ServerMock), not the legacy `mocked` boolean flag --
-        // confirmed via javap, `mocked` does not exist on this generation at all.
-        try {
-            Field mockField = MockBukkit.class.getDeclaredField("mock");
-            mockField.setAccessible(true);
-            mockField.set(null, null);
-        } catch (Exception ignored) {
-        }
+        clearMockHolder();
 
         // DO NOT clear Bukkit.server to null here!
         // MockBukkit.unmock() already does that, and setting it to null
@@ -98,26 +89,64 @@ public final class MockBukkitHelper {
      * {@code Bukkit.server} still holds a live {@code ServerMock}, and the old guard would have torn
      * that server down through the "foreign" path it was written to avoid.</p>
      *
-     * <p>So a {@link ServerMock} occupant is handed back to MockBukkit via {@link #safeUnmock()}
-     * first, letting MockBukkit's own teardown bookkeeping run, and is cleared reflectively only if
-     * that leaves the field still occupied -- which is what an orphaned {@code ServerMock} (holder
-     * already nulled, so {@code unmock()} returns immediately) looks like, and is the same clear
-     * MockBukkit's own {@code setServerInstanceToNull()} performs. Anything else is genuinely
-     * foreign and is cleared directly. Either way the postcondition is the one callers need:
-     * {@code Bukkit.server == null}.</p>
+     * <p><b>Postcondition: BOTH singletons are clear -- {@code Bukkit.server == null} and MockBukkit's
+     * private static {@code mock} holder null.</b> An earlier revision stated only the first half, and
+     * delivered only the first half, which is too weak for the sole caller. {@code MockBukkit.mock(T)}
+     * tests the holder <em>first</em> (offsets 0-15, {@code IllegalStateException: "Already mocking"})
+     * and reaches {@code Bukkit.setServer(...)} only at offset 45, so a run that clears
+     * {@code Bukkit.server} while leaving the holder set does not recover -- it swaps one failure for
+     * another. {@link #safeUnmock()} cannot be relied on to clear either field: it swallows every
+     * exception, and {@code unmock()}'s own exception table covers offsets 25-34 alone, so a throw
+     * from {@code getPluginManager()}/{@code disablePlugins()} (7-22) or from {@code unload()}/
+     * {@code reset()} (34-49) escapes before {@code setServerInstanceToNull()} at offset 49 ever runs.
+     * Measured against the previous implementation with a {@code ServerMock} whose
+     * {@code getPluginManager()} throws: it left {@code Bukkit.server=null, mock!=null} and the next
+     * {@code MockBukkit.mock()} threw {@code IllegalStateException: Already mocking}.</p>
+     *
+     * <p>So a {@link ServerMock} occupant is still handed back to MockBukkit via {@link #safeUnmock()}
+     * first, letting MockBukkit's own teardown bookkeeping run; both fields are then cleared
+     * unconditionally and independently -- the same pair {@code setServerInstanceToNull()} clears, with
+     * the holder clear shared with {@link #ensureCleanState()} through {@link #clearMockHolder()}
+     * rather than written a third time. Clearing an already-null field is a no-op, so the
+     * unconditional form is also correct for a genuinely foreign occupant and for an orphaned holder
+     * with no server at all -- a state the old {@code occupant == null} early return left untouched.
+     * Each clear sits in its own {@code try}, so a failure of one cannot skip the other; if reflection
+     * itself fails the postcondition is unmet, but the caller's immediately following
+     * {@code MockBukkit.mock()} then fails loudly rather than silently.</p>
      */
     public static void clearForeignServer() {
+        if (Bukkit.getServer() instanceof ServerMock) {
+            safeUnmock();
+        }
+        clearBukkitServerField();
+        clearMockHolder();
+    }
+
+    /**
+     * Nulls MockBukkit's private static {@code mock} holder -- the field {@link MockBukkit#isMocked()}
+     * reads and the field {@code MockBukkit.mock(T)} guards on before installing a new server.
+     *
+     * <p>NOTE (14-09): on the 1.21 generation this field is named {@code mock} (a private static
+     * {@link ServerMock}), not the legacy {@code mocked} boolean flag -- confirmed via javap,
+     * {@code mocked} does not exist on this generation at all.</p>
+     */
+    private static void clearMockHolder() {
         try {
-            Server occupant = Bukkit.getServer();
-            if (occupant == null) {
-                return;
-            }
-            if (occupant instanceof ServerMock) {
-                safeUnmock();
-                if (Bukkit.getServer() == null) {
-                    return;
-                }
-            }
+            Field mockField = MockBukkit.class.getDeclaredField("mock");
+            mockField.setAccessible(true);
+            mockField.set(null, null);
+        } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Nulls {@code Bukkit.server} reflectively, which is what MockBukkit's own
+     * {@code setServerInstanceToNull()} does. {@code Bukkit} exposes no public setter that can
+     * displace an existing occupant -- {@code Bukkit.setServer(...)} throws
+     * {@code UnsupportedOperationException} whenever the field is already populated.
+     */
+    private static void clearBukkitServerField() {
+        try {
             Field serverField = Bukkit.class.getDeclaredField("server");
             serverField.setAccessible(true);
             serverField.set(null, null);


### PR DESCRIPTION
## Issue closure

None

## Summary

Bootstraps a live test-time Bukkit server (`org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.101.0`)
for `UltiEssentials`, and migrates this module off the legacy
`com.github.seeseemelk:MockBukkit-v1.19:3.1.0` — the second and last module in the ecosystem to
carry that legacy dependency. This is the largest and riskiest diff in Phase 14's fan-out: twelve
migrated files (eleven test classes + `MockBukkitHelper`) plus three remediated ones.

**This module's suite is one of only two in the whole ecosystem migration that already bootstraps a
live test-time server at all, and — per `12-PHASE14-HANDOFF.md`'s own most-valuable finding for this
phase — the legacy generation does not fail uniformly. It produces three distinct symptom shapes on
Paper 1.21, and all three are verified closed separately in this PR, not assumed closed by a single
fix.**

## Before / after Surefire summary

| State | Result |
|---|---|
| Pre-plan baseline (`origin/master`) | `Tests run: 896, Failures: 0, Errors: 11, Skipped: 52` |
| Post-migration, pre-remediation (isolated measurement) | `Tests run: 900, Failures: 0, Errors: 4, Skipped: 52` |
| Final | `Tests run: 900, Failures: 0, Errors: 0, Skipped: 52` |

`900`, not `896` — this PR's own reopen-guard sentinel (`UltiEssentialsRegistrySentinelTest`) adds 4
tests. **Fewer errors after the migration than expected (4, not 11), measured and reported rather
than absorbed**: removing the legacy jar (which shadowed `mockbukkit-v1.21`'s own classpath
resources — see "Notable findings" below) let the new generation's ServiceLoader-registered
`RegistryAccess` resolve `Material.asBlockType()` with no live server at all, closing shape 1
(`HealCommandTest`) and shape 2 (`WildCommandTest`/`WildCommandSafetyCheckTest`, 7 rows) for free,
with **zero source changes to either class**. Only shape 3 (`BanListenerMockitoTest`, 4 rows)
needed an actual code change.

## Three symptom shapes, each verified separately and in isolation

| Shape | Class | Root cause | Fix |
|---|---|---|---|
| 1 — `Attribute` resolves cleanly | `HealCommandTest` | N/A — already correct | None needed; confirmed still 6/6 in isolation after the migration |
| 2 — `Material.asBlockType()` / `RegistryAccess` | `WildCommandTest`, `WildCommandSafetyCheckTest` | Legacy jar's `RegistryAccess` story conflicted with `mockbukkit-v1.21`'s ServiceLoader registration | None needed — closed by the dependency swap alone; confirmed 3/3 and 6/6 in isolation |
| 3 — `Bukkit.createProfile()` silently null | `BanListenerMockitoTest` | This class's own `EssentialsTestHelper.setUp()` fixture installs a raw, unstubbed Mockito `Server` mock; an unstubbed `createProfile(...)` call returns Mockito's default (`null`) | Explicit `MockBukkit.mock()`/`unmock()` bootstrap added to this class's own `@BeforeEach`/`@AfterEach`, confirmed 5/5 in isolation |

All four classes pass with `mvn -B test -Dtest=<Class>` run completely alone — not just as part of
the full suite — so no class's greenness depends on another class's bootstrap.

## Notable findings (full detail in the phase evidence ledger, not part of this repo)

- **A classpath *resource* collision, not a class collision, between the two MockBukkit
  generations.** Both `MockBukkit-v1.19-3.1.0.jar` and `mockbukkit-v1.21-4.101.0.jar` ship data
  files at the identical path `tags/items/*.json`. While both were briefly declared side by side
  (to prove the new mechanism works before removing the old one), the legacy jar's copy shadowed
  the new one on the classpath, breaking `MockBukkit.mock()` itself with `IllegalArgumentException:
  The value is not a valid namespaced key`. Fixed by declaration order for that one intermediate
  commit; permanently resolved once the legacy dependency was removed.
- **The plan's own premise that "the eleven legacy-bootstrapped classes currently pass" was false,
  measured directly.** All eleven are class-level `@Disabled("Requires Bukkit runtime...")` and were
  never executing — they account for 43 of the pre-existing 52 skips. There was no actual regression
  risk from the mechanical import migration.
- **`BanListenerMockitoTest`'s failure does not depend on cross-class leakage**, contrary to this
  plan's own stated reasoning — confirmed by running it in complete isolation before any fix and
  reproducing all 4 errors identically. The actual cause is this class's own fixture, as detailed
  above.
- **`MockBukkit.mocked` (the legacy boolean field `MockBukkitHelper` clears reflectively) does not
  exist on the 1.21 generation** — confirmed via `javap`, 0 matches. The 1.21 generation uses a
  `private static ServerMock mock` field instead; `MockBukkitHelper` was rewritten accordingly
  rather than left as a silent no-op.

## Migrated files

12 files migrated off the legacy generation (mechanical import-prefix swap, no API differences found
beyond the import path — confirmed via `javap` against the real jar before editing):
`MockBukkitHelper`, `UltiEssentialsTest`, `BanServiceTest`, `HomeServiceTest`, `TeleportServiceTest`,
`TpaServiceTest`, `WarpServiceTest`, `ChestLockServiceTest`, `BaseEssentialsCommandTest`,
`LocationDataEntityTest`, `WarpDataTest`, `HomeDataTest`.

`jitpack.io` is deliberately kept (still needed for `com.github.cryptomorin:XSeries`); its comment
was retargeted since it previously named MockBukkit.

## Jar cleanliness

Built jar (`target/UltiEssentials-1.0.0.jar`) has 0 `org/mockbukkit/` and 0 `be/seeseemelk/`
entries, 111 `com/ultikits/plugins/essentials/` entries (positive control).

## Pre-merge gates

Per the monorepo's Product-Code Phase Ship Gate: this PR is opened under the standing merge
authority but is **not intended to be merged by this automated run**.

- [ ] Gate 1 — own code review (GSD `code-review`)
- [ ] Gate 2 — third-party review (Codacy + ChatGPT/Codex)
- [ ] Gate 3 — Laojun real-machine UAT
- [ ] Gate 4 — required/configured CI green

None of the four gates has been run as part of this plan. Opening the PR is pre-authorized; merging
is explicitly out of scope for this plan.
